### PR TITLE
feat: add rate limit handling with retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ pip install "mypy>=1.0.0"                  # For type checking
    export DATABASE_URL="postgresql://username:password@localhost:5432/artist_bios"
    export OPENAI_PROMPT_ID="your-prompt-id-here"  # Optional
    export OPENAI_ORG_ID="your-org-id-here"        # Optional
+   export OPENAI_RPM="500"                       # Optional
+   export OPENAI_TPM="200000"                    # Optional
+   export OPENAI_TPD="2000000"                   # Optional
    ```
 
    Or create a `.env.local` file:
@@ -92,6 +95,9 @@ pip install "mypy>=1.0.0"                  # For type checking
    DATABASE_URL=postgresql://username:password@localhost:5432/artist_bios
    OPENAI_PROMPT_ID=your-prompt-id-here
    OPENAI_ORG_ID=your-org-id-here
+   OPENAI_RPM=500
+   OPENAI_TPM=200000
+   OPENAI_TPD=2000000
    ```
 
 4. **Set up PostgreSQL database:**
@@ -141,6 +147,9 @@ python3 run_artists.py --input-file artists.csv --prompt-id your-prompt-id
 | `--openai-api-key` | OpenAI API key | `OPENAI_API_KEY` env var | ❌ |
 | `--openai-prompt-id` | OpenAI prompt ID | `OPENAI_PROMPT_ID` env var | ❌ |
 | `--openai-org-id` | OpenAI organization ID | `OPENAI_ORG_ID` env var | ❌ |
+| `--openai-rpm` | Requests per minute limit | `OPENAI_RPM` env var | ❌ |
+| `--openai-tpm` | Tokens per minute limit | `OPENAI_TPM` env var | ❌ |
+| `--openai-tpd` | Tokens per day limit | `OPENAI_TPD` env var | ❌ |
 | `--db-url` | Database URL | `DATABASE_URL` env var | ❌ |
 
 ### Configuration Precedence

--- a/artist_bio_gen/api/__init__.py
+++ b/artist_bio_gen/api/__init__.py
@@ -15,9 +15,10 @@ from .operations import (
 )
 
 from .utils import (
+    RateLimiter,
     should_retry_error,
     calculate_retry_delay,
-    retry_with_exponential_backoff,
+    call_with_retry,
 )
 
 __all__ = [
@@ -26,7 +27,8 @@ __all__ = [
     # Operations
     "call_openai_api",
     # Utilities
+    "RateLimiter",
     "should_retry_error",
     "calculate_retry_delay",
-    "retry_with_exponential_backoff",
+    "call_with_retry",
 ]

--- a/artist_bio_gen/api/utils.py
+++ b/artist_bio_gen/api/utils.py
@@ -8,10 +8,84 @@ error handling, retry logic, and delay calculations.
 import logging
 import random
 import time
+from collections import deque
 from functools import wraps
-from typing import Callable, Any
+from threading import Lock
+from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
+
+
+class RateLimiter:
+    """Simple thread-safe rate limiter for OpenAI API calls."""
+
+    def __init__(
+        self,
+        rpm: int = 500,
+        tpm: int = 200_000,
+        tpd: int = 2_000_000,
+    ) -> None:
+        self.rpm = rpm
+        self.tpm = tpm
+        self.tpd = tpd
+        self.min_interval = 60.0 / rpm
+        self._next_request_time = time.monotonic()
+        self._tokens_window: deque[tuple[float, int]] = deque()
+        self._tokens_day = 0
+        self._avg_tokens = 0.0
+        self._lock = Lock()
+
+    def _purge_window(self, now: float) -> None:
+        while self._tokens_window and now - self._tokens_window[0][0] > 60:
+            self._tokens_window.popleft()
+
+    def estimate_tokens(self) -> int:
+        return max(1, int(self._avg_tokens) or 1)
+
+    def wait(
+        self, tokens_estimate: Optional[int] = None, worker_id: str = "main"
+    ) -> None:
+        if tokens_estimate is None:
+            tokens_estimate = self.estimate_tokens()
+
+        with self._lock:
+            now = time.monotonic()
+            if now < self._next_request_time:
+                delay = self._next_request_time - now
+                logger.debug(f"[{worker_id}] Throttling for RPM: sleeping {delay:.2f}s")
+                time.sleep(delay)
+                now = time.monotonic()
+            self._next_request_time = now + self.min_interval
+
+            wall = time.time()
+            self._purge_window(wall)
+            tokens_last_minute = sum(t for _, t in self._tokens_window)
+            if tokens_last_minute + tokens_estimate > self.tpm:
+                excess = tokens_last_minute + tokens_estimate - self.tpm
+                wait_until = wall
+                cumulative = tokens_last_minute
+                for ts, tok in self._tokens_window:
+                    cumulative -= tok
+                    if cumulative + tokens_estimate <= self.tpm:
+                        wait_until = ts + 60
+                        break
+                delay = max(0, wait_until - wall)
+                logger.debug(f"[{worker_id}] Throttling for TPM: sleeping {delay:.2f}s")
+                time.sleep(delay)
+                self._next_request_time = (
+                    max(self._next_request_time, time.monotonic()) + self.min_interval
+                )
+
+            if self._tokens_day + tokens_estimate > self.tpd:
+                raise RuntimeError("Daily token cap exceeded")
+
+    def record(self, tokens_used: int) -> None:
+        with self._lock:
+            now = time.time()
+            self._tokens_window.append((now, tokens_used))
+            self._tokens_day += tokens_used
+            self._avg_tokens = self._avg_tokens * 0.9 + tokens_used * 0.1
+            self._purge_window(now)
 
 
 def should_retry_error(exception: Exception) -> bool:
@@ -72,6 +146,55 @@ def calculate_retry_delay(
     jitter = delay * 0.25 * (2 * random.random() - 1)
 
     return max(0.1, delay + jitter)  # Minimum 0.1s delay
+
+
+def call_with_retry(
+    func: Callable[[], Any],
+    *,
+    rate_limiter: RateLimiter,
+    max_retries: int = 5,
+    base_delay: float = 0.5,
+    max_delay: float = 4.0,
+    worker_id: str = "main",
+) -> Any:
+    """Call an OpenAI function with shared rate limiting and retries."""
+
+    last_exception: Optional[Exception] = None
+
+    for attempt in range(max_retries + 1):
+        try:
+            rate_limiter.wait(worker_id=worker_id)
+            response = func()
+            usage = getattr(response, "usage", None)
+            tokens = getattr(usage, "total_tokens", 0) if usage else 0
+            rate_limiter.record(tokens)
+            return response
+        except Exception as e:  # noqa: BLE001
+            last_exception = e
+
+            if attempt == max_retries or not should_retry_error(e):
+                raise
+
+            retry_after = None
+            resp = getattr(e, "response", None)
+            if resp is not None:
+                retry_after = resp.headers.get("Retry-After") or resp.headers.get(
+                    "retry-after"
+                )
+            if retry_after is not None:
+                try:
+                    delay = float(retry_after)
+                except ValueError:
+                    delay = calculate_retry_delay(attempt, base_delay, max_delay)
+            else:
+                delay = calculate_retry_delay(attempt, base_delay, max_delay)
+
+            logger.warning(
+                f"[{worker_id}] Attempt {attempt + 1} failed ({type(e).__name__}), retrying in {delay:.2f}s: {e}"
+            )
+            time.sleep(delay)
+
+    raise last_exception
 
 
 def retry_with_exponential_backoff(

--- a/artist_bio_gen/cli/parser.py
+++ b/artist_bio_gen/cli/parser.py
@@ -1,5 +1,4 @@
-"""
-CLI argument parser module.
+"""CLI argument parser module.
 
 This module handles command-line argument parsing and configuration
 for the artist bio generator application.
@@ -13,8 +12,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Generate artist bios using OpenAI Responses API",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
+        epilog="""Examples:
   python run_artists.py --input-file artists.csv --prompt-id prompt_123
   python run_artists.py --input-file data.txt --max-workers 8
   python run_artists.py --input-file artists.csv --dry-run
@@ -63,45 +61,65 @@ Examples:
     parser.add_argument(
         "--enable-db",
         action="store_true",
-        help="Enable database updates (requires DATABASE_URL env var)"
+        help="Enable database updates (requires DATABASE_URL env var)",
     )
 
     parser.add_argument(
         "--test-mode",
-        action="store_true", 
-        help="Use test_artists table instead of artists table"
+        action="store_true",
+        help="Use test_artists table instead of artists table",
     )
 
     parser.add_argument(
         "--resume",
         action="store_true",
-        help="Resume processing by skipping artists already present in output file"
+        help="Resume processing by skipping artists already present in output file",
     )
-
 
     # Environment variable overrides
     parser.add_argument(
         "--openai-api-key",
         default=None,
-        help="OpenAI API key (default: OPENAI_API_KEY env var)"
+        help="OpenAI API key (default: OPENAI_API_KEY env var)",
     )
 
     parser.add_argument(
         "--openai-prompt-id",
         default=None,
-        help="OpenAI prompt ID (default: OPENAI_PROMPT_ID env var)"
+        help="OpenAI prompt ID (default: OPENAI_PROMPT_ID env var)",
     )
 
     parser.add_argument(
         "--openai-org-id",
         default=None,
-        help="OpenAI organization ID (default: OPENAI_ORG_ID env var)"
+        help="OpenAI organization ID (default: OPENAI_ORG_ID env var)",
+    )
+
+    parser.add_argument(
+        "--openai-rpm",
+        type=int,
+        default=None,
+        help="Requests per minute limit (default: OPENAI_RPM env var or 500)",
+    )
+
+    parser.add_argument(
+        "--openai-tpm",
+        type=int,
+        default=None,
+        help="Tokens per minute limit (default: OPENAI_TPM env var or 200000)",
+    )
+
+    parser.add_argument(
+        "--openai-tpd",
+        type=int,
+        default=None,
+        help="Tokens per day limit (default: OPENAI_TPD env var or 2000000)",
     )
 
     parser.add_argument(
         "--db-url",
         default=None,
-        help="Database URL (default: DATABASE_URL env var)"
+        help="Database URL (default: DATABASE_URL env var)",
     )
 
     return parser

--- a/artist_bio_gen/config/env.py
+++ b/artist_bio_gen/config/env.py
@@ -22,6 +22,7 @@ _ENV: Optional["Env"] = None
 
 class ConfigError(Exception):
     """Raised when configuration validation fails."""
+
     pass
 
 
@@ -29,84 +30,106 @@ class ConfigError(Exception):
 class Env:
     """
     Immutable configuration container for environment variables.
-    
+
     Loads configuration from multiple sources with precedence:
     1. CLI overrides (highest priority)
     2. OS environment variables
     3. .env.local file (if python-dotenv available)
     4. Defaults (lowest priority)
     """
-    
+
     OPENAI_API_KEY: str
     DATABASE_URL: str
     OPENAI_PROMPT_ID: Optional[str] = None
     OPENAI_ORG_ID: Optional[str] = None
+    OPENAI_RPM: int = 500
+    OPENAI_TPM: int = 200_000
+    OPENAI_TPD: int = 2_000_000
 
     @staticmethod
     def load(cli_overrides: Optional[Mapping[str, str]] = None) -> "Env":
         """
         Load configuration from all sources with precedence handling.
-        
+
         Loading order (lowest to highest priority):
         1. Defaults (None for optional fields)
         2. .env.local file (if python-dotenv is installed and file exists)
         3. OS environment variables
         4. CLI overrides (highest priority)
-        
+
         Args:
             cli_overrides: Optional mapping of CLI-provided values
-            
+
         Returns:
             Configured Env instance
-            
+
         Raises:
             ConfigError: If required fields are missing or invalid
         """
         global _ENV
-        
+
         # Start with defaults
         values = {
             "OPENAI_API_KEY": None,
             "DATABASE_URL": None,
             "OPENAI_PROMPT_ID": None,
             "OPENAI_ORG_ID": None,
+            "OPENAI_RPM": 500,
+            "OPENAI_TPM": 200_000,
+            "OPENAI_TPD": 2_000_000,
         }
-        
+
         # Step 2: Load from .env.local file (optional)
         _load_from_dotenv_file(values)
-        
+
         # Step 3: Load from OS environment
         for key in values.keys():
             env_value = os.getenv(key)
-            if env_value is not None:
-                values[key] = env_value.strip() if env_value.strip() else None
-        
+            if env_value is not None and env_value.strip():
+                if key in {"OPENAI_RPM", "OPENAI_TPM", "OPENAI_TPD"}:
+                    try:
+                        values[key] = int(env_value.strip())
+                    except ValueError:
+                        logger.warning(f"Invalid integer for {key} in environment")
+                else:
+                    values[key] = env_value.strip()
+
         # Step 4: Apply CLI overrides (highest priority)
         if cli_overrides:
             for key, value in cli_overrides.items():
                 if key in values and value is not None:
-                    values[key] = value.strip() if value.strip() else None
-        
+                    if key in {"OPENAI_RPM", "OPENAI_TPM", "OPENAI_TPD"}:
+                        values[key] = int(value)
+                    else:
+                        values[key] = value.strip() if value.strip() else None
+
         # Validation: Check required fields
         missing_required = []
         if not values["OPENAI_API_KEY"]:
             missing_required.append("OPENAI_API_KEY")
         if not values["DATABASE_URL"]:
             missing_required.append("DATABASE_URL")
-            
+
         if missing_required:
             for field in missing_required:
-                logger.error(f"ERROR: {field} is required but was not provided (env/CLI).")
-            raise ConfigError(f"Missing required configuration: {', '.join(missing_required)}")
-        
+                logger.error(
+                    f"ERROR: {field} is required but was not provided (env/CLI)."
+                )
+            raise ConfigError(
+                f"Missing required configuration: {', '.join(missing_required)}"
+            )
+
         # Create and store singleton instance
         _ENV = Env(
             OPENAI_API_KEY=values["OPENAI_API_KEY"],
-            DATABASE_URL=values["DATABASE_URL"], 
+            DATABASE_URL=values["DATABASE_URL"],
             OPENAI_PROMPT_ID=values["OPENAI_PROMPT_ID"],
             OPENAI_ORG_ID=values["OPENAI_ORG_ID"],
+            OPENAI_RPM=values["OPENAI_RPM"],
+            OPENAI_TPM=values["OPENAI_TPM"],
+            OPENAI_TPD=values["OPENAI_TPD"],
         )
-        
+
         logger.debug("Environment configuration loaded successfully")
         return _ENV
 
@@ -114,10 +137,10 @@ class Env:
     def current() -> "Env":
         """
         Return the globally-initialized Env instance.
-        
+
         Returns:
             The current Env instance
-            
+
         Raises:
             ConfigError: If Env.load() has not been called yet
         """
@@ -128,7 +151,7 @@ class Env:
     def to_dict(self) -> dict:
         """
         Convert environment to dictionary representation.
-        
+
         Returns:
             Dictionary with all configuration values
         """
@@ -137,19 +160,22 @@ class Env:
             "DATABASE_URL": self.DATABASE_URL,
             "OPENAI_PROMPT_ID": self.OPENAI_PROMPT_ID,
             "OPENAI_ORG_ID": self.OPENAI_ORG_ID,
+            "OPENAI_RPM": self.OPENAI_RPM,
+            "OPENAI_TPM": self.OPENAI_TPM,
+            "OPENAI_TPD": self.OPENAI_TPD,
         }
 
     @classmethod
     def from_mapping(cls, mapping: Mapping[str, str]) -> "Env":
         """
         Create Env instance from mapping (useful for testing).
-        
+
         Args:
             mapping: Dictionary of configuration values
-            
+
         Returns:
             Env instance
-            
+
         Raises:
             ConfigError: If required fields are missing
         """
@@ -158,28 +184,36 @@ class Env:
         database_url = mapping.get("DATABASE_URL")
         openai_prompt_id = mapping.get("OPENAI_PROMPT_ID")
         openai_org_id = mapping.get("OPENAI_ORG_ID")
-        
+        openai_rpm = int(mapping.get("OPENAI_RPM", 500))
+        openai_tpm = int(mapping.get("OPENAI_TPM", 200_000))
+        openai_tpd = int(mapping.get("OPENAI_TPD", 2_000_000))
+
         # Validate required fields
         missing_required = []
         if not openai_api_key:
             missing_required.append("OPENAI_API_KEY")
         if not database_url:
             missing_required.append("DATABASE_URL")
-            
+
         if missing_required:
-            raise ConfigError(f"Missing required configuration: {', '.join(missing_required)}")
-        
+            raise ConfigError(
+                f"Missing required configuration: {', '.join(missing_required)}"
+            )
+
         return cls(
             OPENAI_API_KEY=openai_api_key,
             DATABASE_URL=database_url,
             OPENAI_PROMPT_ID=openai_prompt_id,
             OPENAI_ORG_ID=openai_org_id,
+            OPENAI_RPM=openai_rpm,
+            OPENAI_TPM=openai_tpm,
+            OPENAI_TPD=openai_tpd,
         )
 
     def mask(self) -> dict:
         """
         Return masked version for safe logging (hides sensitive values).
-        
+
         Returns:
             Dictionary with sensitive values masked
         """
@@ -187,27 +221,30 @@ class Env:
             "OPENAI_API_KEY": "***" if self.OPENAI_API_KEY else None,
             "DATABASE_URL": "***" if self.DATABASE_URL else None,
             "OPENAI_PROMPT_ID": self.OPENAI_PROMPT_ID,  # Not sensitive
-            "OPENAI_ORG_ID": self.OPENAI_ORG_ID,        # Not sensitive
+            "OPENAI_ORG_ID": self.OPENAI_ORG_ID,  # Not sensitive
+            "OPENAI_RPM": self.OPENAI_RPM,
+            "OPENAI_TPM": self.OPENAI_TPM,
+            "OPENAI_TPD": self.OPENAI_TPD,
         }
 
 
 def _load_from_dotenv_file(values: dict) -> None:
     """
     Load values from .env.local file if python-dotenv is available.
-    
+
     Args:
         values: Dictionary to update with loaded values
     """
     try:
         from dotenv import load_dotenv
-        
+
         # Load .env.local file if it exists, don't override existing values
         if os.path.exists(".env.local"):
             load_dotenv(".env.local", override=False)
             logger.debug("Loaded configuration from .env.local file")
         else:
             logger.debug(".env.local file not found, skipping")
-            
+
     except ImportError:
         # python-dotenv not available, continue silently
         logger.debug("python-dotenv not available, skipping .env.local file loading")

--- a/tests/api/test_rate_limit.py
+++ b/tests/api/test_rate_limit.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Tests for rate limiting and retry logic."""
+
+import unittest
+from unittest.mock import patch
+
+import httpx
+from openai import RateLimitError
+
+from artist_bio_gen.api import RateLimiter, call_with_retry
+
+
+class _DummyResponse:
+    class Usage:
+        total_tokens = 5
+
+    usage = Usage()
+
+
+def _build_rate_limit_error(seconds: int = 1) -> RateLimitError:
+    response = httpx.Response(
+        429,
+        headers={"Retry-After": str(seconds)},
+        request=httpx.Request("GET", "http://test"),
+    )
+    return RateLimitError("rate limit", response=response, body=None)
+
+
+class TestRateLimiter(unittest.TestCase):
+    def test_daily_cap_exceeded(self):
+        limiter = RateLimiter(rpm=1000, tpm=100000, tpd=20)
+        limiter.record(15)
+        with self.assertRaises(RuntimeError):
+            limiter.wait(tokens_estimate=10)
+
+
+class TestCallWithRetry(unittest.TestCase):
+    def test_retry_after_header(self):
+        limiter = RateLimiter(rpm=1000, tpm=100000, tpd=1000000)
+        attempts = {"count": 0}
+
+        def func():
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise _build_rate_limit_error(1)
+            return _DummyResponse()
+
+        with patch("time.sleep") as sleep:
+            result = call_with_retry(func, rate_limiter=limiter, worker_id="T")
+            self.assertIsInstance(result, _DummyResponse)
+            sleep.assert_any_call(1.0)
+            self.assertEqual(attempts["count"], 2)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/core/test_processor_db_pool.py
+++ b/tests/core/test_processor_db_pool.py
@@ -44,7 +44,17 @@ class TestProcessorDbPool(unittest.TestCase):
         artists = _make_artists(4)
         pool = FakePool()
 
-        def fake_call_openai_api(client, artist, prompt_id, version, worker_id, db_connection, skip_existing, test_mode):
+        def fake_call_openai_api(
+            client,
+            artist,
+            prompt_id,
+            version,
+            worker_id,
+            db_connection,
+            skip_existing,
+            test_mode,
+            rate_limiter=None,
+        ):
             # Return a minimal successful response and duration
             return (
                 ApiResponse(
@@ -61,11 +71,14 @@ class TestProcessorDbPool(unittest.TestCase):
             )
 
         # Create temporary JSONL output file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.jsonl', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
             output_path = f.name
-        
+
         try:
-            with patch("artist_bio_gen.core.processor.call_openai_api", side_effect=fake_call_openai_api):
+            with patch(
+                "artist_bio_gen.core.processor.call_openai_api",
+                side_effect=fake_call_openai_api,
+            ):
                 success, failed = process_artists_concurrent(
                     artists=artists,
                     client=object(),
@@ -95,11 +108,14 @@ class TestProcessorDbPool(unittest.TestCase):
             raise RuntimeError("boom")
 
         # Create temporary JSONL output file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.jsonl', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
             output_path = f.name
-        
+
         try:
-            with patch("artist_bio_gen.core.processor.call_openai_api", side_effect=fake_call_openai_api_fail):
+            with patch(
+                "artist_bio_gen.core.processor.call_openai_api",
+                side_effect=fake_call_openai_api_fail,
+            ):
                 success, failed = process_artists_concurrent(
                     artists=artists,
                     client=object(),
@@ -124,4 +140,3 @@ class TestProcessorDbPool(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/integration/test_streaming_integration.py
+++ b/tests/integration/test_streaming_integration.py
@@ -22,35 +22,41 @@ from artist_bio_gen.models import ApiResponse, ArtistData
 
 
 class TestStreamingIntegration(unittest.TestCase):
-    
+
     def setUp(self):
         """Set up test fixtures."""
         self.temp_files = []
-        
+
     def tearDown(self):
         """Clean up temporary files."""
         for temp_file in self.temp_files:
             if os.path.exists(temp_file):
                 os.unlink(temp_file)
-                
+
     def _create_large_input_file(self, num_artists: int) -> str:
         """Create a large input file with the specified number of artists."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             f.write("# Large dataset integration test\n")
-            f.write("# This file contains test artists for streaming integration testing\n")
+            f.write(
+                "# This file contains test artists for streaming integration testing\n"
+            )
             for i in range(num_artists):
-                f.write(f"{i:08d}-1111-1111-1111-111111111111,Integration Artist {i},Integration test data {i}\n")
+                f.write(
+                    f"{i:08d}-1111-1111-1111-111111111111,Integration Artist {i},Integration test data {i}\n"
+                )
             input_path = f.name
-            
+
         self.temp_files.append(input_path)
         return input_path
-        
+
     def _create_mock_openai_client(self):
         """Create a mock OpenAI client for testing."""
         mock_client = MagicMock()
         return mock_client
-        
-    def _create_mock_api_response(self, artist: ArtistData, success: bool = True) -> tuple:
+
+    def _create_mock_api_response(
+        self, artist: ArtistData, success: bool = True
+    ) -> tuple:
         """Create a mock API response for testing."""
         if success:
             response = ApiResponse(
@@ -72,39 +78,54 @@ class TestStreamingIntegration(unittest.TestCase):
                 response_id="",
                 created=0,
                 db_status="null",
-                error="Mock API error"
+                error="Mock API error",
             )
             duration = 0.05
-            
+
         return response, duration
-        
+
     def test_large_dataset_streaming_integration(self):
         """Test streaming integration with large dataset (1000+ artists)."""
         num_artists = 1000
         input_path = self._create_large_input_file(num_artists)
-        
-        with tempfile.NamedTemporaryFile(suffix='.jsonl', delete=False) as f:
+
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
             output_path = f.name
         self.temp_files.append(output_path)
-        
+
         # Parse the large input file
         start_time = time.time()
         parse_result = parse_input_file(input_path)
         parse_duration = time.time() - start_time
-        
+
         # Validate parsing performance
         self.assertEqual(len(parse_result.artists), num_artists)
-        self.assertLess(parse_duration, 5.0, f"Parsing took too long: {parse_duration:.2f}s")
-        
+        self.assertLess(
+            parse_duration, 5.0, f"Parsing took too long: {parse_duration:.2f}s"
+        )
+
         # Mock the API call to simulate successful processing
-        def mock_call_openai_api(client, artist, prompt_id, version, worker_id, db_connection, skip_existing, test_mode):
+        def mock_call_openai_api(
+            client,
+            artist,
+            prompt_id,
+            version,
+            worker_id,
+            db_connection,
+            skip_existing,
+            test_mode,
+            rate_limiter=None,
+        ):
             return self._create_mock_api_response(artist, success=True)
-            
+
         mock_client = self._create_mock_openai_client()
-        
+
         # Test streaming processing with large dataset
         start_time = time.time()
-        with patch('artist_bio_gen.core.processor.call_openai_api', side_effect=mock_call_openai_api):
+        with patch(
+            "artist_bio_gen.core.processor.call_openai_api",
+            side_effect=mock_call_openai_api,
+        ):
             successful_calls, failed_calls = process_artists_concurrent(
                 artists=parse_result.artists,
                 client=mock_client,
@@ -114,65 +135,85 @@ class TestStreamingIntegration(unittest.TestCase):
                 output_path=output_path,
                 db_pool=None,
                 test_mode=False,
-                resume_mode=False
+                resume_mode=False,
             )
         processing_duration = time.time() - start_time
-        
+
         # Validate processing results
         self.assertEqual(successful_calls, num_artists)
         self.assertEqual(failed_calls, 0)
-        self.assertLess(processing_duration, 30.0, f"Processing took too long: {processing_duration:.2f}s")
-        
+        self.assertLess(
+            processing_duration,
+            30.0,
+            f"Processing took too long: {processing_duration:.2f}s",
+        )
+
         # Validate output file integrity
-        with open(output_path, 'r') as f:
+        with open(output_path, "r") as f:
             lines = f.readlines()
-        
+
         self.assertEqual(len(lines), num_artists)
-        
+
         # Validate each line is valid JSON and contains expected data
         processed_ids = set()
         for i, line in enumerate(lines):
             record = json.loads(line.strip())
-            
+
             # Check required fields
             self.assertIn("artist_id", record)
             self.assertIn("artist_name", record)
             self.assertIn("response_text", record)
-            
+
             # Verify no duplicates
             artist_id = record["artist_id"]
-            self.assertNotIn(artist_id, processed_ids, f"Duplicate artist_id: {artist_id}")
+            self.assertNotIn(
+                artist_id, processed_ids, f"Duplicate artist_id: {artist_id}"
+            )
             processed_ids.add(artist_id)
-            
+
         # Validate that resume functionality can read the output correctly
         resume_processed_ids = get_processed_artist_ids(output_path)
         self.assertEqual(len(resume_processed_ids), num_artists)
         self.assertEqual(resume_processed_ids, processed_ids)
-        
+
     def test_streaming_with_mixed_success_failure(self):
         """Test streaming integration with mixed success and failure responses."""
         num_artists = 100
         failure_rate = 0.2  # 20% failure rate
         input_path = self._create_large_input_file(num_artists)
-        
-        with tempfile.NamedTemporaryFile(suffix='.jsonl', delete=False) as f:
+
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
             output_path = f.name
         self.temp_files.append(output_path)
-        
+
         parse_result = parse_input_file(input_path)
-        
+
         # Mock API call with mixed success/failure
         call_count = 0
-        def mock_call_openai_api_mixed(client, artist, prompt_id, version, worker_id, db_connection, skip_existing, test_mode):
+
+        def mock_call_openai_api_mixed(
+            client,
+            artist,
+            prompt_id,
+            version,
+            worker_id,
+            db_connection,
+            skip_existing,
+            test_mode,
+            rate_limiter=None,
+        ):
             nonlocal call_count
             call_count += 1
             # Fail every 5th call (20% failure rate)
             success = (call_count % 5) != 0
             return self._create_mock_api_response(artist, success=success)
-            
+
         mock_client = self._create_mock_openai_client()
-        
-        with patch('artist_bio_gen.core.processor.call_openai_api', side_effect=mock_call_openai_api_mixed):
+
+        with patch(
+            "artist_bio_gen.core.processor.call_openai_api",
+            side_effect=mock_call_openai_api_mixed,
+        ):
             successful_calls, failed_calls = process_artists_concurrent(
                 artists=parse_result.artists,
                 client=mock_client,
@@ -182,65 +223,79 @@ class TestStreamingIntegration(unittest.TestCase):
                 output_path=output_path,
                 db_pool=None,
                 test_mode=False,
-                resume_mode=False
+                resume_mode=False,
             )
-            
+
         # Validate mixed results
         expected_failures = num_artists // 5  # Every 5th call fails
         expected_successes = num_artists - expected_failures
-        
+
         self.assertEqual(successful_calls, expected_successes)
         self.assertEqual(failed_calls, expected_failures)
-        
+
         # Validate that all responses (success and failure) are written to output
-        with open(output_path, 'r') as f:
+        with open(output_path, "r") as f:
             lines = f.readlines()
         self.assertEqual(len(lines), num_artists)
-        
+
         # Count successful vs failed entries in output
         success_count = 0
         failure_count = 0
-        
+
         for line in lines:
             record = json.loads(line.strip())
             if record.get("error"):
                 failure_count += 1
             else:
                 success_count += 1
-                
+
         self.assertEqual(success_count, expected_successes)
         self.assertEqual(failure_count, expected_failures)
-        
+
         # Resume functionality should only count successful entries
         resume_processed_ids = get_processed_artist_ids(output_path)
         self.assertEqual(len(resume_processed_ids), expected_successes)
-        
+
     def test_resume_integration_with_large_dataset(self):
         """Test resume functionality integration with large dataset."""
         num_artists = 500
         resume_point = 200  # Resume after processing 200 artists
-        
+
         input_path = self._create_large_input_file(num_artists)
-        
-        with tempfile.NamedTemporaryFile(suffix='.jsonl', delete=False) as f:
+
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
             output_path = f.name
         self.temp_files.append(output_path)
-        
+
         parse_result = parse_input_file(input_path)
-        
+
         # Mock API call that tracks processing
         processed_count = 0
-        def mock_call_openai_api_counting(client, artist, prompt_id, version, worker_id, db_connection, skip_existing, test_mode):
+
+        def mock_call_openai_api_counting(
+            client,
+            artist,
+            prompt_id,
+            version,
+            worker_id,
+            db_connection,
+            skip_existing,
+            test_mode,
+            rate_limiter=None,
+        ):
             nonlocal processed_count
             processed_count += 1
             return self._create_mock_api_response(artist, success=True)
-            
+
         mock_client = self._create_mock_openai_client()
-        
+
         # First processing run - process only first portion
         first_batch = parse_result.artists[:resume_point]
-        
-        with patch('artist_bio_gen.core.processor.call_openai_api', side_effect=mock_call_openai_api_counting):
+
+        with patch(
+            "artist_bio_gen.core.processor.call_openai_api",
+            side_effect=mock_call_openai_api_counting,
+        ):
             successful_calls_1, failed_calls_1 = process_artists_concurrent(
                 artists=first_batch,
                 client=mock_client,
@@ -250,32 +305,37 @@ class TestStreamingIntegration(unittest.TestCase):
                 output_path=output_path,
                 db_pool=None,
                 test_mode=False,
-                resume_mode=False
+                resume_mode=False,
             )
-            
+
         # Validate first batch results
         self.assertEqual(successful_calls_1, resume_point)
         self.assertEqual(failed_calls_1, 0)
-        
+
         # Check output file has correct number of entries
-        with open(output_path, 'r') as f:
+        with open(output_path, "r") as f:
             lines_after_first = f.readlines()
         self.assertEqual(len(lines_after_first), resume_point)
-        
+
         # Test resume functionality - parse with skip list
         processed_ids = get_processed_artist_ids(output_path)
         self.assertEqual(len(processed_ids), resume_point)
-        
+
         # Parse input with skip list (simulating resume)
-        parse_result_resume = parse_input_file(input_path, skip_processed_ids=processed_ids)
+        parse_result_resume = parse_input_file(
+            input_path, skip_processed_ids=processed_ids
+        )
         expected_remaining = num_artists - resume_point
         self.assertEqual(len(parse_result_resume.artists), expected_remaining)
-        
+
         # Reset counter for second run
         processed_count = 0
-        
+
         # Second processing run - process remaining artists in resume mode
-        with patch('artist_bio_gen.core.processor.call_openai_api', side_effect=mock_call_openai_api_counting):
+        with patch(
+            "artist_bio_gen.core.processor.call_openai_api",
+            side_effect=mock_call_openai_api_counting,
+        ):
             successful_calls_2, failed_calls_2 = process_artists_concurrent(
                 artists=parse_result_resume.artists,
                 client=mock_client,
@@ -285,47 +345,62 @@ class TestStreamingIntegration(unittest.TestCase):
                 output_path=output_path,
                 db_pool=None,
                 test_mode=False,
-                resume_mode=True  # Resume mode - append to existing file
+                resume_mode=True,  # Resume mode - append to existing file
             )
-            
+
         # Validate second batch results
         self.assertEqual(successful_calls_2, expected_remaining)
         self.assertEqual(failed_calls_2, 0)
-        
+
         # Check final output file has all entries
-        with open(output_path, 'r') as f:
+        with open(output_path, "r") as f:
             final_lines = f.readlines()
         self.assertEqual(len(final_lines), num_artists)
-        
+
         # Validate all artist IDs are present and unique
         final_processed_ids = get_processed_artist_ids(output_path)
         self.assertEqual(len(final_processed_ids), num_artists)
-        
+
         # Verify no duplicates by checking that we have exactly the expected artist IDs
-        expected_ids = {f"{i:08d}-1111-1111-1111-111111111111" for i in range(num_artists)}
+        expected_ids = {
+            f"{i:08d}-1111-1111-1111-111111111111" for i in range(num_artists)
+        }
         self.assertEqual(final_processed_ids, expected_ids)
-        
+
     def test_concurrent_streaming_consistency(self):
         """Test that concurrent streaming maintains consistency."""
         num_artists = 200
         max_workers = 8  # High concurrency
-        
+
         input_path = self._create_large_input_file(num_artists)
-        
-        with tempfile.NamedTemporaryFile(suffix='.jsonl', delete=False) as f:
+
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
             output_path = f.name
         self.temp_files.append(output_path)
-        
+
         parse_result = parse_input_file(input_path)
-        
-        def mock_call_openai_api_concurrent(client, artist, prompt_id, version, worker_id, db_connection, skip_existing, test_mode):
+
+        def mock_call_openai_api_concurrent(
+            client,
+            artist,
+            prompt_id,
+            version,
+            worker_id,
+            db_connection,
+            skip_existing,
+            test_mode,
+            rate_limiter=None,
+        ):
             # Add small random delay to increase chance of race conditions
             time.sleep(0.001)
             return self._create_mock_api_response(artist, success=True)
-            
+
         mock_client = self._create_mock_openai_client()
-        
-        with patch('artist_bio_gen.core.processor.call_openai_api', side_effect=mock_call_openai_api_concurrent):
+
+        with patch(
+            "artist_bio_gen.core.processor.call_openai_api",
+            side_effect=mock_call_openai_api_concurrent,
+        ):
             successful_calls, failed_calls = process_artists_concurrent(
                 artists=parse_result.artists,
                 client=mock_client,
@@ -335,27 +410,31 @@ class TestStreamingIntegration(unittest.TestCase):
                 output_path=output_path,
                 db_pool=None,
                 test_mode=False,
-                resume_mode=False
+                resume_mode=False,
             )
-            
+
         # Validate concurrent processing results
         self.assertEqual(successful_calls, num_artists)
         self.assertEqual(failed_calls, 0)
-        
+
         # Validate output file integrity under high concurrency
-        with open(output_path, 'r') as f:
+        with open(output_path, "r") as f:
             lines = f.readlines()
         self.assertEqual(len(lines), num_artists)
-        
+
         # Validate each line is valid JSON and no corruption occurred
         artist_ids = set()
         for line in lines:
             record = json.loads(line.strip())  # This will fail if JSON is corrupted
-            
+
             artist_id = record["artist_id"]
-            self.assertNotIn(artist_id, artist_ids, f"Duplicate artist_id from race condition: {artist_id}")
+            self.assertNotIn(
+                artist_id,
+                artist_ids,
+                f"Duplicate artist_id from race condition: {artist_id}",
+            )
             artist_ids.add(artist_id)
-            
+
         # Verify we have exactly the expected number of unique entries
         self.assertEqual(len(artist_ids), num_artists)
 


### PR DESCRIPTION
## Summary
- add shared RateLimiter with exponential backoff and retry-after support
- expose CLI and env overrides for RPM, TPM, TPD
- wrap OpenAI calls with centralized throttling and retry logic

## Testing
- `mypy artist_bio_gen --ignore-missing-imports` *(fails: Cannot assign to a type, 34 errors)*
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68b726f83cf08324a32f28325572e15b