### PR TITLE
fix: add deterministic ordering to SQL batching

### DIFF
--- a/plans/batch_update_tools_implementation.md
+++ b/plans/batch_update_tools_implementation.md
@@ -70,7 +70,7 @@ Create tools to generate and execute batch SQL update files from JSONL output, e
 - ✅ Generate batched UPDATE statements (1000 records per batch):
   ```sql
   \echo 'Processing batch 1/N (records 1-1000)...'
-  WITH batch AS (SELECT * FROM temp_bio_updates LIMIT 1000 OFFSET 0)
+  WITH batch AS (SELECT * FROM temp_bio_updates ORDER BY id LIMIT 1000 OFFSET 0)
   UPDATE {table_name} SET bio = batch.bio, updated_at = CURRENT_TIMESTAMP
   FROM batch WHERE {table_name}.id = batch.id;
   ```

--- a/tests/tools/test_generate_batch_update.py
+++ b/tests/tools/test_generate_batch_update.py
@@ -6,7 +6,7 @@ import sys
 from unittest.mock import patch, mock_open
 
 # Add the tools directory to the path so we can import the module
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'tools'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "tools"))
 
 from generate_batch_update import (
     validate_uuid_format,
@@ -20,39 +20,39 @@ from generate_batch_update import (
     generate_output_filenames,
     write_csv_file,
     write_skipped_file,
-    write_sql_file
+    write_sql_file,
 )
 
 
 class TestUUIDValidation(unittest.TestCase):
     """Test UUID validation functionality."""
-    
+
     def test_valid_uuid_formats(self):
         """Test that valid UUIDs are accepted."""
         valid_uuids = [
-            '123e4567-e89b-12d3-a456-426614174000',
-            'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
-            '00000000-0000-0000-0000-000000000000',
-            'ffffffff-ffff-ffff-ffff-ffffffffffff'
+            "123e4567-e89b-12d3-a456-426614174000",
+            "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+            "00000000-0000-0000-0000-000000000000",
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",
         ]
-        
+
         for uuid_str in valid_uuids:
             with self.subTest(uuid=uuid_str):
                 self.assertTrue(validate_uuid_format(uuid_str))
-    
+
     def test_invalid_uuid_formats(self):
         """Test that invalid UUIDs are rejected."""
         invalid_uuids = [
-            'not-a-uuid',
-            '123e4567-e89b-12d3-a456',  # Too short
-            '123e4567-e89b-12d3-a456-426614174000-extra',  # Too long
-            '123g4567-e89b-12d3-a456-426614174000',  # Invalid character
-            '',
+            "not-a-uuid",
+            "123e4567-e89b-12d3-a456",  # Too short
+            "123e4567-e89b-12d3-a456-426614174000-extra",  # Too long
+            "123g4567-e89b-12d3-a456-426614174000",  # Invalid character
+            "",
             None,
             123,
-            '123e4567_e89b_12d3_a456_426614174000'  # Wrong separators
+            "123e4567_e89b_12d3_a456_426614174000",  # Wrong separators
         ]
-        
+
         for uuid_str in invalid_uuids:
             with self.subTest(uuid=uuid_str):
                 self.assertFalse(validate_uuid_format(uuid_str))
@@ -60,28 +60,28 @@ class TestUUIDValidation(unittest.TestCase):
 
 class TestBioValidation(unittest.TestCase):
     """Test bio validation functionality."""
-    
+
     def test_valid_bio_entries(self):
         """Test entries with valid bios (no error)."""
         valid_entries = [
-            {'error': None},
-            {'error': ''},
-            {'error': 'null'},
-            {}  # No error field
+            {"error": None},
+            {"error": ""},
+            {"error": "null"},
+            {},  # No error field
         ]
-        
+
         for entry in valid_entries:
             with self.subTest(entry=entry):
                 self.assertTrue(has_valid_bio(entry))
-    
+
     def test_invalid_bio_entries(self):
         """Test entries with invalid bios (has error)."""
         invalid_entries = [
-            {'error': 'Some error occurred'},
-            {'error': 'Rate limit exceeded'},
-            {'error': 'API error'}
+            {"error": "Some error occurred"},
+            {"error": "Rate limit exceeded"},
+            {"error": "API error"},
         ]
-        
+
         for entry in invalid_entries:
             with self.subTest(entry=entry):
                 self.assertFalse(has_valid_bio(entry))
@@ -89,81 +89,78 @@ class TestBioValidation(unittest.TestCase):
 
 class TestJSONLEntryValidation(unittest.TestCase):
     """Test JSONL entry validation functionality."""
-    
+
     def test_valid_entries(self):
         """Test valid JSONL entries."""
         valid_entries = [
             {
-                'artist_id': '123e4567-e89b-12d3-a456-426614174000',
-                'bio': 'This is a valid bio text',
-                'error': None
+                "artist_id": "123e4567-e89b-12d3-a456-426614174000",
+                "bio": "This is a valid bio text",
+                "error": None,
             },
             {
-                'artist_id': 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
-                'bio': 'Another valid bio',
-                'error': ''
+                "artist_id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+                "bio": "Another valid bio",
+                "error": "",
             },
             {
-                'artist_id': '00000000-0000-0000-0000-000000000000',
-                'bio': 'Valid bio without error field'
-            }
+                "artist_id": "00000000-0000-0000-0000-000000000000",
+                "bio": "Valid bio without error field",
+            },
         ]
-        
+
         for entry in valid_entries:
             with self.subTest(entry=entry):
                 is_valid, error_msg = validate_jsonl_entry(entry)
                 self.assertTrue(is_valid, f"Entry should be valid: {error_msg}")
                 self.assertEqual(error_msg, "")
-    
+
     def test_missing_required_fields(self):
         """Test entries missing required fields."""
         invalid_entries = [
             ({}, "Missing required field 'artist_id'"),
-            ({'artist_id': '123e4567-e89b-12d3-a456-426614174000'}, "Missing required field 'bio'"),
+            (
+                {"artist_id": "123e4567-e89b-12d3-a456-426614174000"},
+                "Missing required field 'bio'",
+            ),
         ]
-        
+
         for entry, expected_error in invalid_entries:
             with self.subTest(entry=entry):
                 is_valid, error_msg = validate_jsonl_entry(entry)
                 self.assertFalse(is_valid)
                 self.assertEqual(error_msg, expected_error)
-    
+
     def test_invalid_uuid(self):
         """Test entries with invalid UUIDs."""
-        entry = {
-            'artist_id': 'not-a-uuid',
-            'bio': 'Valid bio text'
-        }
-        
+        entry = {"artist_id": "not-a-uuid", "bio": "Valid bio text"}
+
         is_valid, error_msg = validate_jsonl_entry(entry)
         self.assertFalse(is_valid)
         self.assertIn("Invalid UUID format", error_msg)
-    
+
     def test_bio_with_error(self):
         """Test entries with bio errors."""
         entry = {
-            'artist_id': '123e4567-e89b-12d3-a456-426614174000',
-            'bio': 'Some bio text',
-            'error': 'API rate limit exceeded'
+            "artist_id": "123e4567-e89b-12d3-a456-426614174000",
+            "bio": "Some bio text",
+            "error": "API rate limit exceeded",
         }
-        
+
         is_valid, error_msg = validate_jsonl_entry(entry)
         self.assertFalse(is_valid)
         self.assertIn("Bio has error", error_msg)
-    
+
     def test_empty_bio(self):
         """Test entries with empty bio content."""
         entries = [
+            {"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": ""},
             {
-                'artist_id': '123e4567-e89b-12d3-a456-426614174000',
-                'bio': ''
+                "artist_id": "123e4567-e89b-12d3-a456-426614174000",
+                "bio": "   ",  # Only whitespace
             },
-            {
-                'artist_id': '123e4567-e89b-12d3-a456-426614174000',
-                'bio': '   '  # Only whitespace
-            }
         ]
-        
+
         for entry in entries:
             with self.subTest(entry=entry):
                 is_valid, error_msg = validate_jsonl_entry(entry)
@@ -173,41 +170,41 @@ class TestJSONLEntryValidation(unittest.TestCase):
 
 class TestJSONLLineParsing(unittest.TestCase):
     """Test JSONL line parsing functionality."""
-    
+
     def test_valid_json_lines(self):
         """Test parsing valid JSON lines."""
         valid_lines = [
             '{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Test bio"}',
             '{"name": "test", "value": 123}',
-            '{}'
+            "{}",
         ]
-        
+
         for line in valid_lines:
             with self.subTest(line=line):
                 entry, error_msg = parse_jsonl_line(line, 1)
                 self.assertIsNotNone(entry)
                 self.assertEqual(error_msg, "")
                 self.assertIsInstance(entry, dict)
-    
+
     def test_invalid_json_lines(self):
         """Test parsing invalid JSON lines."""
         invalid_lines = [
             '{"invalid": json}',  # Missing quotes
-            '{"incomplete": ',    # Incomplete JSON
-            'not json at all',
-            '{"trailing": "comma",}'  # Trailing comma
+            '{"incomplete": ',  # Incomplete JSON
+            "not json at all",
+            '{"trailing": "comma",}',  # Trailing comma
         ]
-        
+
         for line in invalid_lines:
             with self.subTest(line=line):
                 entry, error_msg = parse_jsonl_line(line, 1)
                 self.assertIsNone(entry)
                 self.assertIn("JSON decode error", error_msg)
-    
+
     def test_empty_lines(self):
         """Test parsing empty lines."""
-        empty_lines = ['', '   ', '\n', '\t']
-        
+        empty_lines = ["", "   ", "\n", "\t"]
+
         for line in empty_lines:
             with self.subTest(line=repr(line)):
                 entry, error_msg = parse_jsonl_line(line, 1)
@@ -217,58 +214,62 @@ class TestJSONLLineParsing(unittest.TestCase):
 
 class TestJSONLFileParsing(unittest.TestCase):
     """Test JSONL file parsing functionality."""
-    
+
     def test_parse_valid_file(self):
         """Test parsing a valid JSONL file."""
-        jsonl_content = '''{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1"}
+        jsonl_content = """{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1"}
 {"artist_id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "bio": "Bio 2"}
-{"artist_id": "00000000-0000-0000-0000-000000000000", "bio": "Bio 3"}'''
-        
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.jsonl') as f:
+{"artist_id": "00000000-0000-0000-0000-000000000000", "bio": "Bio 3"}"""
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
             f.write(jsonl_content)
             temp_path = f.name
-        
+
         try:
             valid_entries, invalid_entries, error_messages = parse_jsonl_file(temp_path)
-            
+
             self.assertEqual(len(valid_entries), 3)
             self.assertEqual(len(invalid_entries), 0)
             self.assertEqual(len(error_messages), 0)
-            
+
             # Check that all entries have the expected structure
             for entry in valid_entries:
-                self.assertIn('artist_id', entry)
-                self.assertIn('bio', entry)
-                
+                self.assertIn("artist_id", entry)
+                self.assertIn("bio", entry)
+
         finally:
             os.unlink(temp_path)
-    
+
     def test_parse_mixed_file(self):
         """Test parsing a file with both valid and invalid entries."""
-        jsonl_content = '''{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Valid bio"}
+        jsonl_content = """{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Valid bio"}
 {"artist_id": "invalid-uuid", "bio": "Bio with bad UUID"}
 {"artist_id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "bio": "Valid bio", "error": "Some error"}
 invalid json line
-{"artist_id": "00000000-0000-0000-0000-000000000000", "bio": "Another valid bio"}'''
-        
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.jsonl') as f:
+{"artist_id": "00000000-0000-0000-0000-000000000000", "bio": "Another valid bio"}"""
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
             f.write(jsonl_content)
             temp_path = f.name
-        
+
         try:
             valid_entries, invalid_entries, error_messages = parse_jsonl_file(temp_path)
-            
+
             self.assertEqual(len(valid_entries), 2)  # First and last entries
             self.assertEqual(len(invalid_entries), 2)  # Invalid UUID and error entries
-            self.assertEqual(len(error_messages), 3)  # 2 validation errors + 1 JSON error
-            
+            self.assertEqual(
+                len(error_messages), 3
+            )  # 2 validation errors + 1 JSON error
+
         finally:
             os.unlink(temp_path)
-    
+
     def test_parse_nonexistent_file(self):
         """Test parsing a non-existent file."""
-        valid_entries, invalid_entries, error_messages = parse_jsonl_file('/nonexistent/file.jsonl')
-        
+        valid_entries, invalid_entries, error_messages = parse_jsonl_file(
+            "/nonexistent/file.jsonl"
+        )
+
         self.assertEqual(len(valid_entries), 0)
         self.assertEqual(len(invalid_entries), 0)
         self.assertEqual(len(error_messages), 1)
@@ -277,59 +278,61 @@ invalid json line
 
 class TestArgumentParser(unittest.TestCase):
     """Test command-line argument parsing."""
-    
+
     def test_parser_setup(self):
         """Test that argument parser is set up correctly."""
         parser = setup_argument_parser()
-        
+
         # Test required arguments
         with self.assertRaises(SystemExit):
             parser.parse_args([])  # No arguments should fail
-        
+
         # Test valid arguments
-        args = parser.parse_args(['--input', 'test.jsonl'])
-        self.assertEqual(args.input, 'test.jsonl')
+        args = parser.parse_args(["--input", "test.jsonl"])
+        self.assertEqual(args.input, "test.jsonl")
         self.assertFalse(args.test_mode)
-        self.assertEqual(args.output_dir, '.')
-        
+        self.assertEqual(args.output_dir, ".")
+
         # Test all arguments
-        args = parser.parse_args(['--input', 'test.jsonl', '--test-mode', '--output-dir', '/tmp'])
-        self.assertEqual(args.input, 'test.jsonl')
+        args = parser.parse_args(
+            ["--input", "test.jsonl", "--test-mode", "--output-dir", "/tmp"]
+        )
+        self.assertEqual(args.input, "test.jsonl")
         self.assertTrue(args.test_mode)
-        self.assertEqual(args.output_dir, '/tmp')
-    
+        self.assertEqual(args.output_dir, "/tmp")
+
     def test_argument_validation(self):
         """Test command-line argument validation."""
         # Create a temporary file for testing
         with tempfile.NamedTemporaryFile(delete=False) as f:
             temp_file = f.name
-        
+
         # Create a temporary directory for testing
         temp_dir = tempfile.mkdtemp()
-        
+
         try:
             # Test valid arguments
             class MockArgs:
                 def __init__(self, input_file, output_dir):
                     self.input = input_file
                     self.output_dir = output_dir
-            
+
             valid_args = MockArgs(temp_file, temp_dir)
             errors = validate_arguments(valid_args)
             self.assertEqual(len(errors), 0)
-            
+
             # Test invalid input file
-            invalid_args = MockArgs('/nonexistent/file.jsonl', temp_dir)
+            invalid_args = MockArgs("/nonexistent/file.jsonl", temp_dir)
             errors = validate_arguments(invalid_args)
             self.assertEqual(len(errors), 1)
             self.assertIn("does not exist", errors[0])
-            
+
             # Test invalid output directory
-            invalid_args = MockArgs(temp_file, '/nonexistent/directory')
+            invalid_args = MockArgs(temp_file, "/nonexistent/directory")
             errors = validate_arguments(invalid_args)
             self.assertEqual(len(errors), 1)
             self.assertIn("does not exist", errors[0])
-            
+
         finally:
             os.unlink(temp_file)
             os.rmdir(temp_dir)
@@ -337,408 +340,459 @@ class TestArgumentParser(unittest.TestCase):
 
 class TestDuplicateDetection(unittest.TestCase):
     """Test duplicate detection functionality."""
-    
+
     def test_no_duplicates(self):
         """Test file with no duplicate artist_ids."""
-        jsonl_content = '''{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1"}
+        jsonl_content = """{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1"}
 {"artist_id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "bio": "Bio 2"}
-{"artist_id": "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12", "bio": "Bio 3"}'''
-        
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.jsonl') as f:
+{"artist_id": "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12", "bio": "Bio 3"}"""
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
             f.write(jsonl_content)
             temp_path = f.name
-        
+
         try:
             valid_entries, invalid_entries, error_messages = parse_jsonl_file(temp_path)
-            
+
             self.assertEqual(len(valid_entries), 3)
             self.assertEqual(len(invalid_entries), 0)
             # Only expecting parse success, no duplicate messages
-            duplicate_messages = [msg for msg in error_messages if 'Duplicate' in msg]
+            duplicate_messages = [msg for msg in error_messages if "Duplicate" in msg]
             self.assertEqual(len(duplicate_messages), 0)
-            
+
         finally:
             os.unlink(temp_path)
-    
+
     def test_simple_duplicates(self):
         """Test file with simple duplicate artist_ids."""
-        jsonl_content = '''{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1"}
+        jsonl_content = """{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1"}
 {"artist_id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "bio": "Bio 2"}
 {"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1 duplicate"}
-{"artist_id": "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12", "bio": "Bio 4"}'''
-        
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.jsonl') as f:
+{"artist_id": "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12", "bio": "Bio 4"}"""
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
             f.write(jsonl_content)
             temp_path = f.name
-        
+
         try:
             valid_entries, invalid_entries, error_messages = parse_jsonl_file(temp_path)
-            
+
             # Should have 2 valid entries (lines 2 and 4)
             self.assertEqual(len(valid_entries), 2)
             # Should have 2 invalid entries (both occurrences of duplicate artist_id)
             self.assertEqual(len(invalid_entries), 2)
-            
+
             # Check that duplicate error messages are present
-            duplicate_messages = [msg for msg in error_messages if 'Duplicate artist_id' in msg and 'Line' in msg]
+            duplicate_messages = [
+                msg
+                for msg in error_messages
+                if "Duplicate artist_id" in msg and "Line" in msg
+            ]
             self.assertEqual(len(duplicate_messages), 2)  # One for each occurrence
-            
+
             # Check for duplicate detection summary
-            summary_messages = [msg for msg in error_messages if 'Duplicate detection: found' in msg]
+            summary_messages = [
+                msg for msg in error_messages if "Duplicate detection: found" in msg
+            ]
             self.assertEqual(len(summary_messages), 1)
-            self.assertIn('1 duplicated artist_ids affecting 2 entries', summary_messages[0])
-            
+            self.assertIn(
+                "1 duplicated artist_ids affecting 2 entries", summary_messages[0]
+            )
+
         finally:
             os.unlink(temp_path)
-    
+
     def test_multiple_duplicates(self):
         """Test file with multiple sets of duplicate artist_ids."""
-        jsonl_content = '''{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1"}
+        jsonl_content = """{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1"}
 {"artist_id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "bio": "Bio 2"}
 {"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1 dup"}
 {"artist_id": "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12", "bio": "Bio 4"}
 {"artist_id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "bio": "Bio 2 dup"}
-{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1 dup2"}'''
-        
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.jsonl') as f:
+{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1 dup2"}"""
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
             f.write(jsonl_content)
             temp_path = f.name
-        
+
         try:
             valid_entries, invalid_entries, error_messages = parse_jsonl_file(temp_path)
-            
+
             # Should have 1 valid entry (line 4 only)
             self.assertEqual(len(valid_entries), 1)
             # Should have 5 invalid entries (all duplicate occurrences)
             self.assertEqual(len(invalid_entries), 5)
-            
+
             # Check that duplicate error messages are present for each occurrence
-            duplicate_messages = [msg for msg in error_messages if 'Duplicate artist_id' in msg and 'Line' in msg]
+            duplicate_messages = [
+                msg
+                for msg in error_messages
+                if "Duplicate artist_id" in msg and "Line" in msg
+            ]
             self.assertEqual(len(duplicate_messages), 5)  # All 5 duplicate occurrences
-            
+
             # Check for duplicate detection summary
-            summary_messages = [msg for msg in error_messages if 'Duplicate detection: found' in msg]
+            summary_messages = [
+                msg for msg in error_messages if "Duplicate detection: found" in msg
+            ]
             self.assertEqual(len(summary_messages), 1)
-            self.assertIn('2 duplicated artist_ids affecting 5 entries', summary_messages[0])
-            
+            self.assertIn(
+                "2 duplicated artist_ids affecting 5 entries", summary_messages[0]
+            )
+
         finally:
             os.unlink(temp_path)
-    
+
     def test_duplicates_with_invalid_entries(self):
         """Test duplicate detection with mix of valid, invalid, and duplicate entries."""
-        jsonl_content = '''{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Valid bio"}
+        jsonl_content = """{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Valid bio"}
 {"artist_id": "invalid-uuid", "bio": "Bio with bad UUID"}
 {"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Duplicate valid bio"}
 {"artist_id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "bio": "Bio with error", "error": "API error"}
 {"artist_id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "bio": "Another entry", "error": "Another error"}
-{"artist_id": "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12", "bio": "Valid unique bio"}'''
-        
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.jsonl') as f:
+{"artist_id": "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12", "bio": "Valid unique bio"}"""
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
             f.write(jsonl_content)
             temp_path = f.name
-        
+
         try:
             valid_entries, invalid_entries, error_messages = parse_jsonl_file(temp_path)
-            
+
             # Should have 1 valid entry (line 6 only)
             self.assertEqual(len(valid_entries), 1)
             # Should have 5 invalid entries (1 bad UUID + 4 duplicates)
             self.assertEqual(len(invalid_entries), 5)
-            
+
             # Check error message types
-            uuid_error_messages = [msg for msg in error_messages if 'Invalid UUID format' in msg]
-            duplicate_messages = [msg for msg in error_messages if 'Duplicate artist_id' in msg and 'Line' in msg]
-            
+            uuid_error_messages = [
+                msg for msg in error_messages if "Invalid UUID format" in msg
+            ]
+            duplicate_messages = [
+                msg
+                for msg in error_messages
+                if "Duplicate artist_id" in msg and "Line" in msg
+            ]
+
             self.assertEqual(len(uuid_error_messages), 1)
             self.assertEqual(len(duplicate_messages), 4)  # 2 + 2 duplicate occurrences
-            
+
         finally:
             os.unlink(temp_path)
-    
+
     def test_duplicate_detection_preserves_line_numbers(self):
         """Test that duplicate detection preserves original line numbers."""
-        jsonl_content = '''{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1"}
+        jsonl_content = """{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1"}
 
-{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1 duplicate"}'''
-        
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.jsonl') as f:
+{"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1 duplicate"}"""
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
             f.write(jsonl_content)
             temp_path = f.name
-        
+
         try:
             valid_entries, invalid_entries, error_messages = parse_jsonl_file(temp_path)
-            
+
             # Check that line numbers are correctly reported
-            duplicate_messages = [msg for msg in error_messages if 'Duplicate artist_id' in msg and 'Line' in msg]
+            duplicate_messages = [
+                msg
+                for msg in error_messages
+                if "Duplicate artist_id" in msg and "Line" in msg
+            ]
             self.assertEqual(len(duplicate_messages), 2)
-            
+
             # Should report correct line numbers (1 and 3, skipping empty line 2)
             line_numbers = []
             for msg in duplicate_messages:
-                if 'Line 1:' in msg:
+                if "Line 1:" in msg:
                     line_numbers.append(1)
-                elif 'Line 3:' in msg:
+                elif "Line 3:" in msg:
                     line_numbers.append(3)
-            
+
             self.assertEqual(sorted(line_numbers), [1, 3])
-            
+
         finally:
             os.unlink(temp_path)
 
 
 class TestFileGeneration(unittest.TestCase):
     """Test file generation functionality."""
-    
+
     def test_generate_timestamp(self):
         """Test timestamp generation format."""
         timestamp = generate_timestamp()
-        
+
         # Should be in YYYYMMDD_HHMMSS format
-        self.assertRegex(timestamp, r'^\d{8}_\d{6}$')
-        
+        self.assertRegex(timestamp, r"^\d{8}_\d{6}$")
+
         # Should be current date/time (within reasonable bounds)
         self.assertEqual(len(timestamp), 15)  # YYYYMMDD_HHMMSS = 15 chars
-    
+
     def test_generate_output_filenames(self):
         """Test output filename generation."""
-        timestamp = '20250105_143022'
-        output_dir = '/tmp/test'
-        
-        sql_file, csv_file, skipped_file = generate_output_filenames(timestamp, output_dir)
-        
-        expected_sql = '/tmp/test/batch_update_20250105_143022.sql'
-        expected_csv = '/tmp/test/batch_update_20250105_143022.csv'
-        expected_skipped = '/tmp/test/batch_update_skipped_20250105_143022.jsonl'
-        
+        timestamp = "20250105_143022"
+        output_dir = "/tmp/test"
+
+        sql_file, csv_file, skipped_file = generate_output_filenames(
+            timestamp, output_dir
+        )
+
+        expected_sql = "/tmp/test/batch_update_20250105_143022.sql"
+        expected_csv = "/tmp/test/batch_update_20250105_143022.csv"
+        expected_skipped = "/tmp/test/batch_update_skipped_20250105_143022.jsonl"
+
         self.assertEqual(sql_file, expected_sql)
         self.assertEqual(csv_file, expected_csv)
         self.assertEqual(skipped_file, expected_skipped)
-    
+
     def test_write_csv_file_basic(self):
         """Test basic CSV file writing."""
         valid_entries = [
-            {'artist_id': '123e4567-e89b-12d3-a456-426614174000', 'bio': 'Bio 1'},
-            {'artist_id': 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'bio': 'Bio 2'}
+            {"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Bio 1"},
+            {"artist_id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "bio": "Bio 2"},
         ]
-        
+
         temp_dir = tempfile.mkdtemp()
-        csv_file = os.path.join(temp_dir, 'test.csv')
-        
+        csv_file = os.path.join(temp_dir, "test.csv")
+
         try:
             write_csv_file(valid_entries, csv_file)
-            
+
             # Verify file exists
             self.assertTrue(os.path.exists(csv_file))
-            
+
             # Verify content
-            with open(csv_file, 'r', encoding='utf-8') as f:
+            with open(csv_file, "r", encoding="utf-8") as f:
                 content = f.read()
-                
+
             # Should have header and data rows
-            lines = content.strip().split('\n')
+            lines = content.strip().split("\n")
             self.assertEqual(len(lines), 3)  # Header + 2 data rows
             self.assertIn('"id","bio"', lines[0])
-            self.assertIn('123e4567-e89b-12d3-a456-426614174000', lines[1])
-            self.assertIn('Bio 1', lines[1])
-            
+            self.assertIn("123e4567-e89b-12d3-a456-426614174000", lines[1])
+            self.assertIn("Bio 1", lines[1])
+
         finally:
             if os.path.exists(csv_file):
                 os.unlink(csv_file)
             os.rmdir(temp_dir)
-    
+
     def test_write_csv_file_special_characters(self):
         """Test CSV file writing with special characters."""
         valid_entries = [
-            {'artist_id': '123e4567-e89b-12d3-a456-426614174000', 'bio': 'Bio with "quotes" and\nnewlines'},
-            {'artist_id': 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'bio': 'Bio with, commas and ; semicolons'},
-            {'artist_id': 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12', 'bio': 'Bio with unicode: café 音楽 🎵'}
+            {
+                "artist_id": "123e4567-e89b-12d3-a456-426614174000",
+                "bio": 'Bio with "quotes" and\nnewlines',
+            },
+            {
+                "artist_id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+                "bio": "Bio with, commas and ; semicolons",
+            },
+            {
+                "artist_id": "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12",
+                "bio": "Bio with unicode: café 音楽 🎵",
+            },
         ]
-        
+
         temp_dir = tempfile.mkdtemp()
-        csv_file = os.path.join(temp_dir, 'test_special.csv')
-        
+        csv_file = os.path.join(temp_dir, "test_special.csv")
+
         try:
             write_csv_file(valid_entries, csv_file)
-            
+
             # Verify file exists and can be read back properly
             self.assertTrue(os.path.exists(csv_file))
-            
+
             # Read back using CSV reader to verify proper escaping
             import csv
-            with open(csv_file, 'r', encoding='utf-8') as f:
+
+            with open(csv_file, "r", encoding="utf-8") as f:
                 reader = csv.reader(f)
                 rows = list(reader)
-            
+
             # Should have header + 3 data rows
             self.assertEqual(len(rows), 4)
-            self.assertEqual(rows[0], ['id', 'bio'])
-            
+            self.assertEqual(rows[0], ["id", "bio"])
+
             # Check that special characters are preserved
-            self.assertIn('quotes', rows[1][1])
-            self.assertIn('newlines', rows[1][1])
-            self.assertIn('commas', rows[2][1])
-            self.assertIn('café', rows[3][1])
-            self.assertIn('🎵', rows[3][1])
-            
+            self.assertIn("quotes", rows[1][1])
+            self.assertIn("newlines", rows[1][1])
+            self.assertIn("commas", rows[2][1])
+            self.assertIn("café", rows[3][1])
+            self.assertIn("🎵", rows[3][1])
+
         finally:
             if os.path.exists(csv_file):
                 os.unlink(csv_file)
             os.rmdir(temp_dir)
-    
+
     def test_write_csv_file_empty(self):
         """Test CSV file writing with empty entries."""
         valid_entries = []
-        
+
         temp_dir = tempfile.mkdtemp()
-        csv_file = os.path.join(temp_dir, 'test_empty.csv')
-        
+        csv_file = os.path.join(temp_dir, "test_empty.csv")
+
         try:
             write_csv_file(valid_entries, csv_file)
-            
+
             # Verify file exists and has header only
             self.assertTrue(os.path.exists(csv_file))
-            
-            with open(csv_file, 'r', encoding='utf-8') as f:
+
+            with open(csv_file, "r", encoding="utf-8") as f:
                 content = f.read().strip()
-                
-            lines = content.split('\n')
+
+            lines = content.split("\n")
             self.assertEqual(len(lines), 1)  # Header only
             self.assertEqual(lines[0], '"id","bio"')
-            
+
         finally:
             if os.path.exists(csv_file):
                 os.unlink(csv_file)
             os.rmdir(temp_dir)
-    
+
     def test_write_skipped_file_basic(self):
         """Test basic skipped JSONL file writing."""
         invalid_entries = [
-            {'artist_id': 'invalid-uuid', 'bio': 'Bio with bad UUID', '_error': 'Invalid UUID'},
-            {'artist_id': '123e4567-e89b-12d3-a456-426614174000', 'bio': 'Bio with error', 'error': 'API error', '_line_number': 3}
+            {
+                "artist_id": "invalid-uuid",
+                "bio": "Bio with bad UUID",
+                "_error": "Invalid UUID",
+            },
+            {
+                "artist_id": "123e4567-e89b-12d3-a456-426614174000",
+                "bio": "Bio with error",
+                "error": "API error",
+                "_line_number": 3,
+            },
         ]
-        
+
         temp_dir = tempfile.mkdtemp()
-        skipped_file = os.path.join(temp_dir, 'test_skipped.jsonl')
-        
+        skipped_file = os.path.join(temp_dir, "test_skipped.jsonl")
+
         try:
             write_skipped_file(invalid_entries, skipped_file)
-            
+
             # Verify file exists
             self.assertTrue(os.path.exists(skipped_file))
-            
+
             # Verify content
-            with open(skipped_file, 'r', encoding='utf-8') as f:
+            with open(skipped_file, "r", encoding="utf-8") as f:
                 lines = f.readlines()
-                
+
             self.assertEqual(len(lines), 2)
-            
+
             # Parse each line
             entry1 = json.loads(lines[0].strip())
             entry2 = json.loads(lines[1].strip())
-            
+
             # Should not have internal tracking fields
-            self.assertNotIn('_error', entry1)
-            self.assertNotIn('_line_number', entry1)
-            self.assertNotIn('_error', entry2)
-            self.assertNotIn('_line_number', entry2)
-            
+            self.assertNotIn("_error", entry1)
+            self.assertNotIn("_line_number", entry1)
+            self.assertNotIn("_error", entry2)
+            self.assertNotIn("_line_number", entry2)
+
             # Should have original data
-            self.assertEqual(entry1['artist_id'], 'invalid-uuid')
-            self.assertEqual(entry1['bio'], 'Bio with bad UUID')
-            self.assertEqual(entry2['error'], 'API error')
-            
+            self.assertEqual(entry1["artist_id"], "invalid-uuid")
+            self.assertEqual(entry1["bio"], "Bio with bad UUID")
+            self.assertEqual(entry2["error"], "API error")
+
         finally:
             if os.path.exists(skipped_file):
                 os.unlink(skipped_file)
             os.rmdir(temp_dir)
-    
+
     def test_write_skipped_file_unicode(self):
         """Test skipped JSONL file writing with unicode characters."""
         invalid_entries = [
-            {'artist_id': 'test-id', 'bio': 'Bio with unicode: café 音楽 🎵', '_error': 'Some error'}
+            {
+                "artist_id": "test-id",
+                "bio": "Bio with unicode: café 音楽 🎵",
+                "_error": "Some error",
+            }
         ]
-        
+
         temp_dir = tempfile.mkdtemp()
-        skipped_file = os.path.join(temp_dir, 'test_unicode.jsonl')
-        
+        skipped_file = os.path.join(temp_dir, "test_unicode.jsonl")
+
         try:
             write_skipped_file(invalid_entries, skipped_file)
-            
+
             # Verify file exists and unicode is preserved
             self.assertTrue(os.path.exists(skipped_file))
-            
-            with open(skipped_file, 'r', encoding='utf-8') as f:
+
+            with open(skipped_file, "r", encoding="utf-8") as f:
                 content = f.read()
-                
+
             # Should contain unicode characters
-            self.assertIn('café', content)
-            self.assertIn('音楽', content)
-            self.assertIn('🎵', content)
-            
+            self.assertIn("café", content)
+            self.assertIn("音楽", content)
+            self.assertIn("🎵", content)
+
             # Verify proper JSON parsing
             entry = json.loads(content.strip())
-            self.assertIn('café', entry['bio'])
-            self.assertIn('🎵', entry['bio'])
-            
+            self.assertIn("café", entry["bio"])
+            self.assertIn("🎵", entry["bio"])
+
         finally:
             if os.path.exists(skipped_file):
                 os.unlink(skipped_file)
             os.rmdir(temp_dir)
-    
+
     def test_write_skipped_file_empty(self):
         """Test skipped JSONL file writing with empty entries."""
         invalid_entries = []
-        
+
         temp_dir = tempfile.mkdtemp()
-        skipped_file = os.path.join(temp_dir, 'test_empty_skipped.jsonl')
-        
+        skipped_file = os.path.join(temp_dir, "test_empty_skipped.jsonl")
+
         try:
             write_skipped_file(invalid_entries, skipped_file)
-            
+
             # Verify file exists and is empty
             self.assertTrue(os.path.exists(skipped_file))
-            
-            with open(skipped_file, 'r', encoding='utf-8') as f:
+
+            with open(skipped_file, "r", encoding="utf-8") as f:
                 content = f.read()
-                
-            self.assertEqual(content, '')
-            
+
+            self.assertEqual(content, "")
+
         finally:
             if os.path.exists(skipped_file):
                 os.unlink(skipped_file)
             os.rmdir(temp_dir)
-    
+
     def test_file_generation_atomic_operations(self):
         """Test that file operations are atomic (temp files used)."""
         valid_entries = [
-            {'artist_id': '123e4567-e89b-12d3-a456-426614174000', 'bio': 'Test bio'}
+            {"artist_id": "123e4567-e89b-12d3-a456-426614174000", "bio": "Test bio"}
         ]
-        
+
         temp_dir = tempfile.mkdtemp()
-        csv_file = os.path.join(temp_dir, 'test_atomic.csv')
-        
+        csv_file = os.path.join(temp_dir, "test_atomic.csv")
+
         try:
             # Mock a failure during file writing to test cleanup
             original_rename = os.rename
-            
+
             def failing_rename(src, dst):
                 # Clean up the temp file ourselves to simulate error handling
                 if os.path.exists(src):
                     os.unlink(src)
                 raise OSError("Simulated rename failure")
-            
+
             # This should fail and clean up temp file
-            with patch('os.rename', failing_rename):
+            with patch("os.rename", failing_rename):
                 with self.assertRaises(OSError):
                     write_csv_file(valid_entries, csv_file)
-            
+
             # Final file should not exist
             self.assertFalse(os.path.exists(csv_file))
-            
+
             # No temp files should be left behind
-            temp_files = [f for f in os.listdir(temp_dir) if f.endswith('.csv')]
+            temp_files = [f for f in os.listdir(temp_dir) if f.endswith(".csv")]
             self.assertEqual(len(temp_files), 0)
-            
+
         finally:
             # Cleanup any remaining files
             for f in os.listdir(temp_dir):
@@ -748,192 +802,210 @@ class TestFileGeneration(unittest.TestCase):
 
 class TestSQLGeneration(unittest.TestCase):
     """Test SQL script generation functionality."""
-    
+
     def test_write_sql_file_basic(self):
         """Test basic SQL file generation."""
         temp_dir = tempfile.mkdtemp()
-        csv_file = os.path.join(temp_dir, 'test.csv')
-        sql_file = os.path.join(temp_dir, 'test.sql')
-        
+        csv_file = os.path.join(temp_dir, "test.csv")
+        sql_file = os.path.join(temp_dir, "test.sql")
+
         try:
-            write_sql_file(csv_file, sql_file, 'artists', 2)
-            
+            write_sql_file(csv_file, sql_file, "artists", 2)
+
             # Verify file exists
             self.assertTrue(os.path.exists(sql_file))
-            
+
             # Verify content
-            with open(sql_file, 'r', encoding='utf-8') as f:
+            with open(sql_file, "r", encoding="utf-8") as f:
                 content = f.read()
-                
+
             # Should contain SQL header
-            self.assertIn('\\set ON_ERROR_STOP on', content)
+            self.assertIn("\\set ON_ERROR_STOP on", content)
             self.assertIn("\\echo 'Starting batch bio update...'", content)
-            
+
             # Should contain transaction structure
-            self.assertIn('BEGIN;', content)
-            self.assertIn('CREATE TEMP TABLE temp_bio_updates (id UUID, bio TEXT);', content)
-            self.assertIn("\\copy temp_bio_updates FROM 'test.csv' WITH CSV HEADER;", content)
-            
+            self.assertIn("BEGIN;", content)
+            self.assertIn(
+                "CREATE TEMP TABLE temp_bio_updates (id UUID, bio TEXT);", content
+            )
+            self.assertIn(
+                "\\copy temp_bio_updates FROM 'test.csv' WITH CSV HEADER;", content
+            )
+
             # Should contain single batch UPDATE (2 records = 1 batch)
             self.assertIn("\\echo 'Processing batch 1/1 (records 1-2)...'", content)
-            self.assertIn('UPDATE artists SET bio = batch.bio, updated_at = CURRENT_TIMESTAMP', content)
-            
+            self.assertIn(
+                "UPDATE artists SET bio = batch.bio, updated_at = CURRENT_TIMESTAMP",
+                content,
+            )
+
             # Should contain cleanup
-            self.assertIn('SELECT COUNT(*) as total_processed FROM temp_bio_updates;', content)
-            self.assertIn('DROP TABLE temp_bio_updates;', content)
-            self.assertIn('COMMIT;', content)
+            self.assertIn(
+                "SELECT COUNT(*) as total_processed FROM temp_bio_updates;", content
+            )
+            self.assertIn("DROP TABLE temp_bio_updates;", content)
+            self.assertIn("COMMIT;", content)
             self.assertIn("\\echo 'Batch update completed successfully!'", content)
-            
+
         finally:
             for f in os.listdir(temp_dir):
                 os.unlink(os.path.join(temp_dir, f))
             os.rmdir(temp_dir)
-    
+
     def test_write_sql_file_multiple_batches(self):
         """Test SQL file generation with multiple batches."""
         temp_dir = tempfile.mkdtemp()
-        csv_file = os.path.join(temp_dir, 'large_batch.csv')
-        sql_file = os.path.join(temp_dir, 'large_batch.sql')
-        
+        csv_file = os.path.join(temp_dir, "large_batch.csv")
+        sql_file = os.path.join(temp_dir, "large_batch.sql")
+
         try:
             # Generate SQL for 2500 records (should create 3 batches)
-            write_sql_file(csv_file, sql_file, 'test_artists', 2500)
-            
+            write_sql_file(csv_file, sql_file, "test_artists", 2500)
+
             # Verify file exists
             self.assertTrue(os.path.exists(sql_file))
-            
+
             # Verify content
-            with open(sql_file, 'r', encoding='utf-8') as f:
+            with open(sql_file, "r", encoding="utf-8") as f:
                 content = f.read()
-                
+
             # Should contain 3 batch processing statements
             self.assertIn("\\echo 'Processing batch 1/3 (records 1-1000)...'", content)
-            self.assertIn("\\echo 'Processing batch 2/3 (records 1001-2000)...'", content)
-            self.assertIn("\\echo 'Processing batch 3/3 (records 2001-2500)...'", content)
-            
-            # Should contain correct LIMIT and OFFSET values
-            self.assertIn('LIMIT 1000 OFFSET 0', content)
-            self.assertIn('LIMIT 1000 OFFSET 1000', content)
-            self.assertIn('LIMIT 1000 OFFSET 2000', content)
-            
+            self.assertIn(
+                "\\echo 'Processing batch 2/3 (records 1001-2000)...'", content
+            )
+            self.assertIn(
+                "\\echo 'Processing batch 3/3 (records 2001-2500)...'", content
+            )
+
+            # Should contain correct LIMIT/OFFSET with deterministic ordering
+            self.assertIn("ORDER BY id LIMIT 1000 OFFSET 0", content)
+            self.assertIn("ORDER BY id LIMIT 1000 OFFSET 1000", content)
+            self.assertIn("ORDER BY id LIMIT 1000 OFFSET 2000", content)
+
             # Should use test_artists table
-            self.assertIn('UPDATE test_artists SET bio = batch.bio', content)
-            
+            self.assertIn("UPDATE test_artists SET bio = batch.bio", content)
+
         finally:
             for f in os.listdir(temp_dir):
                 os.unlink(os.path.join(temp_dir, f))
             os.rmdir(temp_dir)
-    
+
     def test_write_sql_file_empty_records(self):
         """Test SQL file generation with zero records."""
         temp_dir = tempfile.mkdtemp()
-        csv_file = os.path.join(temp_dir, 'empty.csv')
-        sql_file = os.path.join(temp_dir, 'empty.sql')
-        
+        csv_file = os.path.join(temp_dir, "empty.csv")
+        sql_file = os.path.join(temp_dir, "empty.sql")
+
         try:
-            write_sql_file(csv_file, sql_file, 'artists', 0)
-            
+            write_sql_file(csv_file, sql_file, "artists", 0)
+
             # Verify file exists
             self.assertTrue(os.path.exists(sql_file))
-            
+
             # Verify content
-            with open(sql_file, 'r', encoding='utf-8') as f:
+            with open(sql_file, "r", encoding="utf-8") as f:
                 content = f.read()
-                
+
             # Should contain basic structure but no batch processing
-            self.assertIn('\\set ON_ERROR_STOP on', content)
-            self.assertIn('CREATE TEMP TABLE temp_bio_updates (id UUID, bio TEXT);', content)
-            self.assertIn('COMMIT;', content)
-            
+            self.assertIn("\\set ON_ERROR_STOP on", content)
+            self.assertIn(
+                "CREATE TEMP TABLE temp_bio_updates (id UUID, bio TEXT);", content
+            )
+            self.assertIn("COMMIT;", content)
+
             # Should NOT contain any batch processing
             self.assertNotIn("\\echo 'Processing batch", content)
-            self.assertNotIn('UPDATE artists SET', content)
-            
+            self.assertNotIn("UPDATE artists SET", content)
+
         finally:
             for f in os.listdir(temp_dir):
                 os.unlink(os.path.join(temp_dir, f))
             os.rmdir(temp_dir)
-    
+
     def test_write_sql_file_custom_batch_size(self):
         """Test SQL file generation with custom batch size."""
         temp_dir = tempfile.mkdtemp()
-        csv_file = os.path.join(temp_dir, 'custom_batch.csv')
-        sql_file = os.path.join(temp_dir, 'custom_batch.sql')
-        
+        csv_file = os.path.join(temp_dir, "custom_batch.csv")
+        sql_file = os.path.join(temp_dir, "custom_batch.sql")
+
         try:
             # Generate SQL for 150 records with batch size of 50
-            write_sql_file(csv_file, sql_file, 'artists', 150, batch_size=50)
-            
+            write_sql_file(csv_file, sql_file, "artists", 150, batch_size=50)
+
             # Verify file exists
             self.assertTrue(os.path.exists(sql_file))
-            
+
             # Verify content
-            with open(sql_file, 'r', encoding='utf-8') as f:
+            with open(sql_file, "r", encoding="utf-8") as f:
                 content = f.read()
-                
+
             # Should contain 3 batches with size 50
             self.assertIn("\\echo 'Processing batch 1/3 (records 1-50)...'", content)
             self.assertIn("\\echo 'Processing batch 2/3 (records 51-100)...'", content)
             self.assertIn("\\echo 'Processing batch 3/3 (records 101-150)...'", content)
-            
-            # Should contain correct LIMIT values
-            self.assertIn('LIMIT 50 OFFSET 0', content)
-            self.assertIn('LIMIT 50 OFFSET 50', content)
-            self.assertIn('LIMIT 50 OFFSET 100', content)
-            
+
+            # Should contain correct LIMIT/OFFSET with deterministic ordering
+            self.assertIn("ORDER BY id LIMIT 50 OFFSET 0", content)
+            self.assertIn("ORDER BY id LIMIT 50 OFFSET 50", content)
+            self.assertIn("ORDER BY id LIMIT 50 OFFSET 100", content)
+
         finally:
             for f in os.listdir(temp_dir):
                 os.unlink(os.path.join(temp_dir, f))
             os.rmdir(temp_dir)
-    
+
     def test_write_sql_file_table_names(self):
         """Test SQL file generation with different table names."""
         temp_dir = tempfile.mkdtemp()
-        csv_file = os.path.join(temp_dir, 'table_test.csv')
-        
-        table_names = ['artists', 'test_artists']
-        
+        csv_file = os.path.join(temp_dir, "table_test.csv")
+
+        table_names = ["artists", "test_artists"]
+
         for table_name in table_names:
-            sql_file = os.path.join(temp_dir, f'{table_name}.sql')
-            
+            sql_file = os.path.join(temp_dir, f"{table_name}.sql")
+
             try:
                 write_sql_file(csv_file, sql_file, table_name, 1)
-                
+
                 # Verify content
-                with open(sql_file, 'r', encoding='utf-8') as f:
+                with open(sql_file, "r", encoding="utf-8") as f:
                     content = f.read()
-                    
+
                 # Should contain correct table name in UPDATE statement
-                self.assertIn(f'UPDATE {table_name} SET bio = batch.bio', content)
-                self.assertIn(f'FROM batch WHERE {table_name}.id = batch.id;', content)
-                
+                self.assertIn(f"UPDATE {table_name} SET bio = batch.bio", content)
+                self.assertIn(f"FROM batch WHERE {table_name}.id = batch.id;", content)
+
             finally:
                 if os.path.exists(sql_file):
                     os.unlink(sql_file)
-        
+
         # Cleanup
         os.rmdir(temp_dir)
-    
+
     def test_write_sql_file_csv_filename_extraction(self):
         """Test that CSV filename is correctly extracted for \\copy command."""
         temp_dir = tempfile.mkdtemp()
-        csv_file = os.path.join(temp_dir, 'subdir', 'complex_name_20250105_143022.csv')
-        sql_file = os.path.join(temp_dir, 'test.sql')
-        
+        csv_file = os.path.join(temp_dir, "subdir", "complex_name_20250105_143022.csv")
+        sql_file = os.path.join(temp_dir, "test.sql")
+
         # Create subdirectory
         os.makedirs(os.path.dirname(csv_file))
-        
+
         try:
-            write_sql_file(csv_file, sql_file, 'artists', 1)
-            
+            write_sql_file(csv_file, sql_file, "artists", 1)
+
             # Verify content
-            with open(sql_file, 'r', encoding='utf-8') as f:
+            with open(sql_file, "r", encoding="utf-8") as f:
                 content = f.read()
-                
+
             # Should use only filename, not full path
-            self.assertIn("\\copy temp_bio_updates FROM 'complex_name_20250105_143022.csv' WITH CSV HEADER;", content)
+            self.assertIn(
+                "\\copy temp_bio_updates FROM 'complex_name_20250105_143022.csv' WITH CSV HEADER;",
+                content,
+            )
             self.assertNotIn(temp_dir, content)  # Should not contain full path
-            
+
         finally:
             for root, dirs, files in os.walk(temp_dir, topdown=False):
                 for file in files:
@@ -941,13 +1013,13 @@ class TestSQLGeneration(unittest.TestCase):
                 for dir in dirs:
                     os.rmdir(os.path.join(root, dir))
             os.rmdir(temp_dir)
-    
+
     def test_write_sql_file_atomic_operations(self):
         """Test that SQL file operations are atomic."""
         temp_dir = tempfile.mkdtemp()
-        csv_file = os.path.join(temp_dir, 'test.csv')
-        sql_file = os.path.join(temp_dir, 'test_atomic.sql')
-        
+        csv_file = os.path.join(temp_dir, "test.csv")
+        sql_file = os.path.join(temp_dir, "test_atomic.sql")
+
         try:
             # Mock a failure during file writing to test cleanup
             def failing_rename(src, dst):
@@ -955,19 +1027,19 @@ class TestSQLGeneration(unittest.TestCase):
                 if os.path.exists(src):
                     os.unlink(src)
                 raise OSError("Simulated rename failure")
-            
+
             # This should fail and clean up temp file
-            with patch('os.rename', failing_rename):
+            with patch("os.rename", failing_rename):
                 with self.assertRaises(OSError):
-                    write_sql_file(csv_file, sql_file, 'artists', 1)
-            
+                    write_sql_file(csv_file, sql_file, "artists", 1)
+
             # Final file should not exist
             self.assertFalse(os.path.exists(sql_file))
-            
+
             # No temp files should be left behind
-            temp_files = [f for f in os.listdir(temp_dir) if f.endswith('.sql')]
+            temp_files = [f for f in os.listdir(temp_dir) if f.endswith(".sql")]
             self.assertEqual(len(temp_files), 0)
-            
+
         finally:
             # Cleanup any remaining files
             for f in os.listdir(temp_dir):
@@ -975,5 +1047,5 @@ class TestSQLGeneration(unittest.TestCase):
             os.rmdir(temp_dir)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tools/generate_batch_update.py
+++ b/tools/generate_batch_update.py
@@ -120,7 +120,7 @@ def parse_jsonl_file(file_path: str) -> Tuple[list, list, list]:
     """
     # First pass: parse all entries and collect artist_ids to detect duplicates
     all_parsed_entries = []
-    artist_id_counts = {}
+    artist_id_counts: Dict[str, int] = {}
     error_messages = []
 
     try:
@@ -374,7 +374,8 @@ def write_sql_file(
             temp_file.write("CREATE TEMP TABLE temp_bio_updates (id UUID, bio TEXT);\n")
             temp_file.write("\n")
 
-            # Copy data from CSV file
+            # Copy CSV data into the temp table using psql \copy
+            # Use only the basename so the script references a relative path
             csv_filename = os.path.basename(csv_file_path)
             temp_file.write(
                 f"\\copy temp_bio_updates FROM '{csv_filename}' WITH CSV HEADER;\n"

--- a/tools/generate_batch_update.py
+++ b/tools/generate_batch_update.py
@@ -20,10 +20,10 @@ from typing import Dict, Any, Optional, Tuple
 def validate_uuid_format(artist_id: str) -> bool:
     """
     Validate that the artist_id is a properly formatted UUID.
-    
+
     Args:
         artist_id: The artist ID string to validate
-        
+
     Returns:
         bool: True if valid UUID format, False otherwise
     """
@@ -40,65 +40,67 @@ def validate_uuid_format(artist_id: str) -> bool:
 def has_valid_bio(entry: Dict[str, Any]) -> bool:
     """
     Check if the entry has a valid bio (error field is null/empty).
-    
+
     Args:
         entry: The JSONL entry dictionary
-        
+
     Returns:
         bool: True if bio is valid (no error), False otherwise
     """
-    error_field = entry.get('error')
-    return error_field is None or error_field == '' or error_field == 'null'
+    error_field = entry.get("error")
+    return error_field is None or error_field == "" or error_field == "null"
 
 
 def validate_jsonl_entry(entry: Dict[str, Any]) -> Tuple[bool, str]:
     """
     Validate a JSONL entry for required fields and data integrity.
-    
+
     Args:
         entry: The parsed JSONL entry dictionary
-        
+
     Returns:
         Tuple[bool, str]: (is_valid, error_message)
     """
     # Check for required fields
-    if 'artist_id' not in entry:
+    if "artist_id" not in entry:
         return False, "Missing required field 'artist_id'"
-    
-    if 'bio' not in entry:
+
+    if "bio" not in entry:
         return False, "Missing required field 'bio'"
-    
+
     # Validate UUID format
-    if not validate_uuid_format(entry['artist_id']):
+    if not validate_uuid_format(entry["artist_id"]):
         return False, f"Invalid UUID format for artist_id: {entry['artist_id']}"
-    
+
     # Check if bio is valid (no error)
     if not has_valid_bio(entry):
         return False, f"Bio has error: {entry.get('error', 'Unknown error')}"
-    
+
     # Check if bio content exists and is not empty
-    bio = entry.get('bio', '').strip()
+    bio = entry.get("bio", "").strip()
     if not bio:
         return False, "Bio content is empty"
-    
+
     return True, ""
 
 
-def parse_jsonl_line(line: str, line_number: int) -> Tuple[Optional[Dict[str, Any]], str]:
+def parse_jsonl_line(
+    line: str, line_number: int
+) -> Tuple[Optional[Dict[str, Any]], str]:
     """
     Parse a single JSONL line with error handling.
-    
+
     Args:
         line: The JSONL line to parse
         line_number: Line number for error reporting
-        
+
     Returns:
         Tuple[Optional[Dict], str]: (parsed_entry, error_message)
     """
     line = line.strip()
     if not line:
         return None, ""  # Skip empty lines
-    
+
     try:
         entry = json.loads(line)
         return entry, ""
@@ -109,10 +111,10 @@ def parse_jsonl_line(line: str, line_number: int) -> Tuple[Optional[Dict[str, An
 def parse_jsonl_file(file_path: str) -> Tuple[list, list, list]:
     """
     Parse JSONL file line by line with comprehensive error handling and duplicate detection.
-    
+
     Args:
         file_path: Path to the JSONL input file
-        
+
     Returns:
         Tuple[list, list, list]: (valid_entries, invalid_entries, error_messages)
     """
@@ -120,29 +122,29 @@ def parse_jsonl_file(file_path: str) -> Tuple[list, list, list]:
     all_parsed_entries = []
     artist_id_counts = {}
     error_messages = []
-    
+
     try:
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             for line_number, line in enumerate(f, 1):
                 # Parse the JSON line
                 entry, parse_error = parse_jsonl_line(line, line_number)
-                
+
                 if parse_error:
                     error_messages.append(parse_error)
                     continue
-                
+
                 if entry is None:  # Empty line
                     continue
-                
+
                 # Store entry with line number for processing
-                entry['_line_number'] = line_number
+                entry["_line_number"] = line_number
                 all_parsed_entries.append(entry)
-                
+
                 # Track artist_id counts for duplicate detection
-                artist_id = entry.get('artist_id')
+                artist_id = entry.get("artist_id")
                 if artist_id:
                     artist_id_counts[artist_id] = artist_id_counts.get(artist_id, 0) + 1
-                    
+
     except FileNotFoundError:
         error_messages.append(f"Input file not found: {file_path}")
         return [], [], error_messages
@@ -152,144 +154,149 @@ def parse_jsonl_file(file_path: str) -> Tuple[list, list, list]:
     except Exception as e:
         error_messages.append(f"Unexpected error reading file: {str(e)}")
         return [], [], error_messages
-    
+
     # Identify duplicated artist_ids
-    duplicated_artist_ids = {aid for aid, count in artist_id_counts.items() if count > 1}
-    
+    duplicated_artist_ids = {
+        aid for aid, count in artist_id_counts.items() if count > 1
+    }
+
     # Second pass: process entries and separate valid, invalid, and duplicates
     valid_entries = []
     invalid_entries = []
     duplicate_entries = []
-    
+
     for entry in all_parsed_entries:
-        line_number = entry['_line_number']
-        artist_id = entry.get('artist_id')
-        
+        line_number = entry["_line_number"]
+        artist_id = entry.get("artist_id")
+
         # Check if this artist_id is duplicated
         if artist_id and artist_id in duplicated_artist_ids:
-            error_messages.append(f"Line {line_number}: Duplicate artist_id: {artist_id}")
-            entry['_error'] = f"Duplicate artist_id: {artist_id}"
+            error_messages.append(
+                f"Line {line_number}: Duplicate artist_id: {artist_id}"
+            )
+            entry["_error"] = f"Duplicate artist_id: {artist_id}"
             duplicate_entries.append(entry)
             continue
-        
+
         # Validate the entry
         is_valid, validation_error = validate_jsonl_entry(entry)
-        
+
         if is_valid:
             # Remove internal tracking fields before adding to valid entries
-            clean_entry = {k: v for k, v in entry.items() if not k.startswith('_')}
+            clean_entry = {k: v for k, v in entry.items() if not k.startswith("_")}
             valid_entries.append(clean_entry)
         else:
             error_messages.append(f"Line {line_number}: {validation_error}")
-            entry['_error'] = validation_error
+            entry["_error"] = validation_error
             invalid_entries.append(entry)
-    
+
     # Combine invalid and duplicate entries
     all_invalid_entries = invalid_entries + duplicate_entries
-    
+
     # Log duplicate detection summary
     if duplicated_artist_ids:
-        error_messages.append(f"Duplicate detection: found {len(duplicated_artist_ids)} duplicated artist_ids affecting {sum(artist_id_counts[aid] for aid in duplicated_artist_ids)} entries")
-    
+        error_messages.append(
+            f"Duplicate detection: found {len(duplicated_artist_ids)} duplicated artist_ids affecting {sum(artist_id_counts[aid] for aid in duplicated_artist_ids)} entries"
+        )
+
     return valid_entries, all_invalid_entries, error_messages
 
 
 def setup_argument_parser() -> argparse.ArgumentParser:
     """
     Set up command-line argument parser.
-    
+
     Returns:
         argparse.ArgumentParser: Configured argument parser
     """
     parser = argparse.ArgumentParser(
-        description='Generate SQL batch update files from JSONL output',
+        description="Generate SQL batch update files from JSONL output",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
   %(prog)s --input out.jsonl
   %(prog)s --input out.jsonl --test-mode
   %(prog)s --input out.jsonl --output-dir /tmp/batches
-        """
+        """,
     )
-    
+
     parser.add_argument(
-        '--input',
+        "--input", type=str, required=True, help="Input JSONL file path (required)"
+    )
+
+    parser.add_argument(
+        "--test-mode",
+        action="store_true",
+        help="Use test_artists table instead of artists table",
+    )
+
+    parser.add_argument(
+        "--output-dir",
         type=str,
-        required=True,
-        help='Input JSONL file path (required)'
+        default=".",
+        help="Output directory for generated files (default: current directory)",
     )
-    
-    parser.add_argument(
-        '--test-mode',
-        action='store_true',
-        help='Use test_artists table instead of artists table'
-    )
-    
-    parser.add_argument(
-        '--output-dir',
-        type=str,
-        default='.',
-        help='Output directory for generated files (default: current directory)'
-    )
-    
+
     return parser
 
 
 def generate_timestamp() -> str:
     """
     Generate timestamp in YYYYMMDD_HHMMSS format.
-    
+
     Returns:
         str: Formatted timestamp string
     """
-    return datetime.now().strftime('%Y%m%d_%H%M%S')
+    return datetime.now().strftime("%Y%m%d_%H%M%S")
 
 
 def generate_output_filenames(timestamp: str, output_dir: str) -> Tuple[str, str, str]:
     """
     Generate output filenames based on timestamp.
-    
+
     Args:
         timestamp: Timestamp string in YYYYMMDD_HHMMSS format
         output_dir: Output directory path
-        
+
     Returns:
         Tuple[str, str, str]: (sql_file, csv_file, skipped_file) paths
     """
-    sql_file = os.path.join(output_dir, f'batch_update_{timestamp}.sql')
-    csv_file = os.path.join(output_dir, f'batch_update_{timestamp}.csv')
-    skipped_file = os.path.join(output_dir, f'batch_update_skipped_{timestamp}.jsonl')
-    
+    sql_file = os.path.join(output_dir, f"batch_update_{timestamp}.sql")
+    csv_file = os.path.join(output_dir, f"batch_update_{timestamp}.csv")
+    skipped_file = os.path.join(output_dir, f"batch_update_skipped_{timestamp}.jsonl")
+
     return sql_file, csv_file, skipped_file
 
 
 def write_csv_file(valid_entries: list, csv_file_path: str) -> None:
     """
     Write valid entries to CSV file with UTF-8 support and proper escaping.
-    
+
     Args:
         valid_entries: List of valid JSONL entries
         csv_file_path: Path to output CSV file
     """
     # Create temporary file first for atomic writes
-    temp_fd, temp_path = tempfile.mkstemp(suffix='.csv', dir=os.path.dirname(csv_file_path))
-    
+    temp_fd, temp_path = tempfile.mkstemp(
+        suffix=".csv", dir=os.path.dirname(csv_file_path)
+    )
+
     try:
-        with os.fdopen(temp_fd, 'w', encoding='utf-8', newline='') as temp_file:
+        with os.fdopen(temp_fd, "w", encoding="utf-8", newline="") as temp_file:
             writer = csv.writer(temp_file, quoting=csv.QUOTE_ALL)
-            
+
             # Write header
-            writer.writerow(['id', 'bio'])
-            
+            writer.writerow(["id", "bio"])
+
             # Write data rows
             for entry in valid_entries:
-                artist_id = entry['artist_id']
-                bio = entry['bio']
+                artist_id = entry["artist_id"]
+                bio = entry["bio"]
                 writer.writerow([artist_id, bio])
-        
+
         # Move temp file to final location
         os.rename(temp_path, csv_file_path)
-        
+
     except Exception as e:
         # Clean up temp file on error
         try:
@@ -302,25 +309,27 @@ def write_csv_file(valid_entries: list, csv_file_path: str) -> None:
 def write_skipped_file(invalid_entries: list, skipped_file_path: str) -> None:
     """
     Write invalid/skipped entries to JSONL file.
-    
+
     Args:
         invalid_entries: List of invalid JSONL entries
         skipped_file_path: Path to output skipped JSONL file
     """
     # Create temporary file first for atomic writes
-    temp_fd, temp_path = tempfile.mkstemp(suffix='.jsonl', dir=os.path.dirname(skipped_file_path))
-    
+    temp_fd, temp_path = tempfile.mkstemp(
+        suffix=".jsonl", dir=os.path.dirname(skipped_file_path)
+    )
+
     try:
-        with os.fdopen(temp_fd, 'w', encoding='utf-8') as temp_file:
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as temp_file:
             for entry in invalid_entries:
                 # Remove internal tracking fields before writing
-                clean_entry = {k: v for k, v in entry.items() if not k.startswith('_')}
+                clean_entry = {k: v for k, v in entry.items() if not k.startswith("_")}
                 json.dump(clean_entry, temp_file, ensure_ascii=False)
-                temp_file.write('\n')
-        
+                temp_file.write("\n")
+
         # Move temp file to final location
         os.rename(temp_path, skipped_file_path)
-        
+
     except Exception as e:
         # Clean up temp file on error
         try:
@@ -330,10 +339,16 @@ def write_skipped_file(invalid_entries: list, skipped_file_path: str) -> None:
         raise e
 
 
-def write_sql_file(csv_file_path: str, sql_file_path: str, table_name: str, total_records: int, batch_size: int = 1000) -> None:
+def write_sql_file(
+    csv_file_path: str,
+    sql_file_path: str,
+    table_name: str,
+    total_records: int,
+    batch_size: int = 1000,
+) -> None:
     """
     Generate SQL script file with batched UPDATE statements.
-    
+
     Args:
         csv_file_path: Path to the CSV data file
         sql_file_path: Path to output SQL script file
@@ -342,50 +357,64 @@ def write_sql_file(csv_file_path: str, sql_file_path: str, table_name: str, tota
         batch_size: Number of records per batch (default: 1000)
     """
     # Create temporary file first for atomic writes
-    temp_fd, temp_path = tempfile.mkstemp(suffix='.sql', dir=os.path.dirname(sql_file_path))
-    
+    temp_fd, temp_path = tempfile.mkstemp(
+        suffix=".sql", dir=os.path.dirname(sql_file_path)
+    )
+
     try:
-        with os.fdopen(temp_fd, 'w', encoding='utf-8') as temp_file:
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as temp_file:
             # Write SQL header with error handling
-            temp_file.write('\\set ON_ERROR_STOP on\n')
+            temp_file.write("\\set ON_ERROR_STOP on\n")
             temp_file.write("\\echo 'Starting batch bio update...'\n")
-            temp_file.write('\n')
-            
+            temp_file.write("\n")
+
             # Begin transaction and create temp table
-            temp_file.write('BEGIN;\n')
-            temp_file.write('\n')
-            temp_file.write('CREATE TEMP TABLE temp_bio_updates (id UUID, bio TEXT);\n')
-            temp_file.write('\n')
-            
+            temp_file.write("BEGIN;\n")
+            temp_file.write("\n")
+            temp_file.write("CREATE TEMP TABLE temp_bio_updates (id UUID, bio TEXT);\n")
+            temp_file.write("\n")
+
             # Copy data from CSV file
             csv_filename = os.path.basename(csv_file_path)
-            temp_file.write(f"\\copy temp_bio_updates FROM '{csv_filename}' WITH CSV HEADER;\n")
-            temp_file.write('\n')
-            
+            temp_file.write(
+                f"\\copy temp_bio_updates FROM '{csv_filename}' WITH CSV HEADER;\n"
+            )
+            temp_file.write("\n")
+
             # Generate batched UPDATE statements
             if total_records > 0:
-                num_batches = (total_records + batch_size - 1) // batch_size  # Ceiling division
-                
+                num_batches = (
+                    total_records + batch_size - 1
+                ) // batch_size  # Ceiling division
+
                 for batch_num in range(num_batches):
                     offset = batch_num * batch_size
                     current_batch_size = min(batch_size, total_records - offset)
                     batch_end = offset + current_batch_size
-                    
-                    temp_file.write(f"\\echo 'Processing batch {batch_num + 1}/{num_batches} (records {offset + 1}-{batch_end})...'\n")
-                    temp_file.write(f'WITH batch AS (SELECT * FROM temp_bio_updates LIMIT {batch_size} OFFSET {offset})\n')
-                    temp_file.write(f'UPDATE {table_name} SET bio = batch.bio, updated_at = CURRENT_TIMESTAMP\n')
-                    temp_file.write(f'FROM batch WHERE {table_name}.id = batch.id;\n')
-                    temp_file.write('\n')
-            
+
+                    temp_file.write(
+                        f"\\echo 'Processing batch {batch_num + 1}/{num_batches} (records {offset + 1}-{batch_end})...'\n"
+                    )
+                    temp_file.write(
+                        f"WITH batch AS (SELECT * FROM temp_bio_updates ORDER BY id LIMIT {batch_size} OFFSET {offset})\n"
+                    )
+                    temp_file.write(
+                        f"UPDATE {table_name} SET bio = batch.bio, updated_at = CURRENT_TIMESTAMP\n"
+                    )
+                    temp_file.write(f"FROM batch WHERE {table_name}.id = batch.id;\n")
+                    temp_file.write("\n")
+
             # Add cleanup and summary
-            temp_file.write('SELECT COUNT(*) as total_processed FROM temp_bio_updates;\n')
-            temp_file.write('DROP TABLE temp_bio_updates;\n')
-            temp_file.write('COMMIT;\n')
+            temp_file.write(
+                "SELECT COUNT(*) as total_processed FROM temp_bio_updates;\n"
+            )
+            temp_file.write("DROP TABLE temp_bio_updates;\n")
+            temp_file.write("COMMIT;\n")
             temp_file.write("\\echo 'Batch update completed successfully!'\n")
-        
+
         # Move temp file to final location
         os.rename(temp_path, sql_file_path)
-        
+
     except Exception as e:
         # Clean up temp file on error
         try:
@@ -398,15 +427,15 @@ def write_sql_file(csv_file_path: str, sql_file_path: str, table_name: str, tota
 def validate_arguments(args: argparse.Namespace) -> list:
     """
     Validate command-line arguments.
-    
+
     Args:
         args: Parsed command-line arguments
-        
+
     Returns:
         list: List of validation error messages
     """
     errors = []
-    
+
     # Validate input file
     if not os.path.exists(args.input):
         errors.append(f"Input file does not exist: {args.input}")
@@ -414,7 +443,7 @@ def validate_arguments(args: argparse.Namespace) -> list:
         errors.append(f"Input path is not a file: {args.input}")
     elif not os.access(args.input, os.R_OK):
         errors.append(f"Input file is not readable: {args.input}")
-    
+
     # Validate output directory
     if not os.path.exists(args.output_dir):
         errors.append(f"Output directory does not exist: {args.output_dir}")
@@ -422,7 +451,7 @@ def validate_arguments(args: argparse.Namespace) -> list:
         errors.append(f"Output path is not a directory: {args.output_dir}")
     elif not os.access(args.output_dir, os.W_OK):
         errors.append(f"Output directory is not writable: {args.output_dir}")
-    
+
     return errors
 
 
@@ -430,7 +459,7 @@ def main():
     """Main entry point for the batch update generator."""
     parser = setup_argument_parser()
     args = parser.parse_args()
-    
+
     # Validate arguments
     validation_errors = validate_arguments(args)
     if validation_errors:
@@ -438,59 +467,65 @@ def main():
         for error in validation_errors:
             print(f"  {error}", file=sys.stderr)
         sys.exit(1)
-    
+
     # Parse JSONL file
     print(f"Processing JSONL file: {args.input}")
     valid_entries, invalid_entries, error_messages = parse_jsonl_file(args.input)
-    
+
     # Print any error messages
     if error_messages:
         print("Warnings and errors during parsing:", file=sys.stderr)
         for error in error_messages:
             print(f"  {error}", file=sys.stderr)
-    
+
     # Print summary statistics
     print(f"\nParsing Summary:")
     print(f"  Valid entries: {len(valid_entries)}")
     print(f"  Invalid entries: {len(invalid_entries)}")
     print(f"  Parse errors: {len(error_messages)}")
-    
+
     table_name = "test_artists" if args.test_mode else "artists"
     print(f"  Target table: {table_name}")
     print(f"  Output directory: {args.output_dir}")
-    
+
     # Generate files if we have any data to process
     if valid_entries or invalid_entries:
         print(f"\nGenerating output files...")
-        
+
         # Generate timestamp and filenames
         timestamp = generate_timestamp()
-        sql_file, csv_file, skipped_file = generate_output_filenames(timestamp, args.output_dir)
-        
+        sql_file, csv_file, skipped_file = generate_output_filenames(
+            timestamp, args.output_dir
+        )
+
         try:
             # Write CSV file for valid entries
             if valid_entries:
                 write_csv_file(valid_entries, csv_file)
                 print(f"  Created CSV file: {csv_file}")
-            
+
             # Write skipped JSONL file for invalid entries
             if invalid_entries:
                 write_skipped_file(invalid_entries, skipped_file)
                 print(f"  Created skipped file: {skipped_file}")
-            
+
             # Generate SQL script file
             if valid_entries:
                 write_sql_file(csv_file, sql_file, table_name, len(valid_entries))
                 print(f"  Created SQL file: {sql_file}")
             else:
                 print(f"  No valid entries - SQL file not created")
-            
+
             print(f"\nFile generation completed successfully!")
             print(f"  Timestamp: {timestamp}")
             if valid_entries:
-                num_batches = (len(valid_entries) + 999) // 1000  # Ceiling division for 1000 batch size
-                print(f"  Generated {num_batches} batch(es) for {len(valid_entries)} records")
-            
+                num_batches = (
+                    len(valid_entries) + 999
+                ) // 1000  # Ceiling division for 1000 batch size
+                print(
+                    f"  Generated {num_batches} batch(es) for {len(valid_entries)} records"
+                )
+
         except Exception as e:
             print(f"Error generating files: {str(e)}", file=sys.stderr)
             sys.exit(1)
@@ -498,5 +533,5 @@ def main():
         print("\nNo data to process - no output files generated.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- order temp table rows by id before applying LIMIT/OFFSET
- update tests and docs for ordered batching

## Testing
- `mypy artist_bio_gen/` *(fails: Unsupported target for indexed assignment, Need type annotation, Incompatible types)*
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb6b5b188c8324adf24916052d20d2