### PR TITLE
fix: avoid psql password prompt hang in run_batch_update

### DIFF
--- a/tools/run_batch_update.sh
+++ b/tools/run_batch_update.sh
@@ -118,9 +118,9 @@ validate_database_connection() {
         return 1
     fi
     
-    # Test database connectivity
+    # Test database connectivity without password prompt
     echo "Testing database connectivity..."
-    if ! psql "$DATABASE_URL" -c "SELECT 1" >/dev/null 2>&1; then
+    if ! psql "$DATABASE_URL" --no-password -c "SELECT 1" >/dev/null 2>&1; then
         echo "Error: Failed to connect to database" >&2
         echo "Please verify your DATABASE_URL is correct and the database is accessible" >&2
         echo "DATABASE_URL format: postgresql://user:pass@host:port/dbname" >&2


### PR DESCRIPTION
## Summary
- prevent `psql` from prompting for a password during connection tests
- tidy shell script end-of-file newline

## Testing
- `black artist_bio_gen/ tests/`
- `mypy artist_bio_gen/` *(fails: Unsupported target for indexed assignment)*
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68bca4d406448324b9005133375bfbcf