### PR TITLE
fix: guard SQL file execution in batch update script

### DIFF
--- a/tools/run_batch_update.sh
+++ b/tools/run_batch_update.sh
@@ -163,8 +163,7 @@ main() {
     local failed_count=0
     
     for sql_file in "${sql_files[@]}"; do
-        execute_sql_file "$sql_file" "$scan_directory"
-        if [[ $? -eq 0 ]]; then
+        if execute_sql_file "$sql_file" "$scan_directory"; then
             ((processed_count++))
         else
             ((failed_count++))


### PR DESCRIPTION
## Summary
- guard `execute_sql_file` call with conditional to avoid `set -e` exiting loop prematurely

## Testing
- `black --check artist_bio_gen/ tests/` *(fails: would reformat 31 files)*
- `mypy artist_bio_gen/` *(fails: found 29 errors in 8 files)*
- `python3 run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcad73a1fc832491e8c0a952da8822