### PR TITLE
feat(config,cli): add quota configuration parameters (Task 2.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,22 @@ OPENAI_PROMPT_ID=your_prompt_id_here
 # Optional: OpenAI Organization ID (can also use --openai-org-id)
 # Uncomment if you belong to multiple organizations
 # OPENAI_ORG_ID=your_org_id_here
+
+# ------------------------------------------------------------
+# Quota Monitoring Configuration (Task 2.2)
+# ------------------------------------------------------------
+
+# Enable or disable quota monitoring (true/false). Default: true
+QUOTA_MONITORING=true
+
+# Pause threshold as decimal between 0.1 and 1.0. Default: 0.8
+QUOTA_THRESHOLD=0.8
+
+# Optional daily request budget to trigger pausing. Leave empty to disable
+DAILY_REQUEST_LIMIT=
+
+# Hours to pause when quota is hit (1-72). Default: 24
+PAUSE_DURATION_HOURS=24
+
+# Log quota metrics every N requests to reduce noise. Default: 100
+QUOTA_LOG_INTERVAL=100

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,60 @@
+## Title
+
+<!-- Use Conventional Commits: feat:, fix:, docs:, chore:, refactor:, test: -->
+<!-- Example: feat(api): integrate raw response header parsing (Task 2.1) -->
+
+## Summary
+
+- What changed and why (1–3 bullets)
+- Context/links to plans or specs (e.g., plans/rate_limit_implementation_plan.md)
+
+## Linked Issues
+
+- Closes #<issue-number>
+- Related to #<issue-number>
+
+## How To Run
+
+```bash
+# Full test suite (offline-safe)
+python3 run_tests.py
+
+# Format and type-check
+black artist_bio_gen/ tests/
+mypy artist_bio_gen/
+
+# Example run (adjust flags as needed)
+python3 run_artists.py \
+  --input-file examples/example_artists.csv \
+  --prompt-id <id> \
+  --output out.jsonl \
+  --dry-run
+```
+
+## Sample Output
+
+<!-- Paste a small snippet (5–10 lines) showing expected stdout and/or out.jsonl records. -->
+
+```text
+<paste a brief, anonymized excerpt of stdout>
+```
+
+```jsonl
+{"artist_id": "...", "artist_name": "...", "response_text": "...", "response_id": "..."}
+```
+
+## Checklist
+
+- [ ] Tests pass locally: `python3 run_tests.py`
+- [ ] Code formatted: `black artist_bio_gen/ tests/`
+- [ ] Type checks pass: `mypy artist_bio_gen/`
+- [ ] No secrets committed; .env.local ignored
+- [ ] README/help text updated if CLI flags changed
+- [ ] Plan updated (if part of a tracked plan) and task marked completed
+
+## Risk & Rollout
+
+- Risk: Low / Medium / High
+- Rollout: Merge → monitor → revert plan if needed
+- Notes: Any migration, config, or operational considerations
+

--- a/artist_bio_gen/cli/main.py
+++ b/artist_bio_gen/cli/main.py
@@ -76,7 +76,20 @@ def _build_cli_overrides(args) -> dict:
     # Handle special case for prompt-id which could come from --prompt-id or --openai-prompt-id
     if hasattr(args, "prompt_id") and args.prompt_id is not None:
         overrides["OPENAI_PROMPT_ID"] = args.prompt_id
-    
+
+    # Quota-related flags map directly to env-style keys when explicitly provided
+    # Only include if not None (ensures truly explicit CLI setting)
+    if getattr(args, "quota_threshold", None) is not None:
+        overrides["QUOTA_THRESHOLD"] = str(args.quota_threshold)
+    if getattr(args, "quota_monitoring", None) is not None:
+        overrides["QUOTA_MONITORING"] = str(args.quota_monitoring)
+    if getattr(args, "daily_limit", None) is not None:
+        overrides["DAILY_REQUEST_LIMIT"] = str(args.daily_limit)
+    if getattr(args, "pause_duration", None) is not None:
+        overrides["PAUSE_DURATION_HOURS"] = str(args.pause_duration)
+    if getattr(args, "quota_log_interval", None) is not None:
+        overrides["QUOTA_LOG_INTERVAL"] = str(args.quota_log_interval)
+
     return overrides
 
 

--- a/artist_bio_gen/cli/parser.py
+++ b/artist_bio_gen/cli/parser.py
@@ -78,6 +78,42 @@ Examples:
         help="Resume processing by skipping artists already present in output file"
     )
 
+    # Quota monitoring and control flags (Task 2.2)
+    parser.add_argument(
+        "--quota-threshold",
+        type=float,
+        default=None,
+        help="Pause threshold as a decimal between 0.1 and 1.0 (default: 0.8)",
+    )
+
+    parser.add_argument(
+        "--quota-monitoring",
+        choices=["true", "false"],
+        default=None,
+        help="Enable or disable quota monitoring (default: true)",
+    )
+
+    parser.add_argument(
+        "--daily-limit",
+        type=int,
+        default=None,
+        help="Optional daily request limit used for pausing (no default)",
+    )
+
+    parser.add_argument(
+        "--pause-duration",
+        type=int,
+        default=None,
+        help="Hours to pause when quota is hit (1-72, default: 24)",
+    )
+
+    parser.add_argument(
+        "--quota-log-interval",
+        type=int,
+        default=None,
+        help="Log quota metrics every N requests to reduce noise (default: 100)",
+    )
+
 
     # Environment variable overrides
     parser.add_argument(

--- a/plans/rate_limit_implementation_plan.md
+++ b/plans/rate_limit_implementation_plan.md
@@ -214,12 +214,12 @@ QUOTA_LOG_INTERVAL=100
 ```
 
 **Acceptance Criteria**:
-- [ ] All quota parameters configurable via CLI and environment variables
-- [ ] Default monitoring enabled (no dev/prod differences)
-- [ ] Validation ranges: threshold 0.1-1.0, pause_duration 1-72 hours
-- [ ] Update `.env.example` with documentation
-- [ ] Backward compatibility maintained
-- [ ] Help text for all new parameters
+- [x] All quota parameters configurable via CLI and environment variables
+- [x] Default monitoring enabled (no dev/prod differences)
+- [x] Validation ranges: threshold 0.1-1.0, pause_duration 1-72 hours
+- [x] Update `.env.example` with documentation
+- [x] Backward compatibility maintained
+- [x] Help text for all new parameters
 
 ### Task 2.3: Implement Pause/Resume Logic in Processor
 **File**: `artist_bio_gen/core/processor.py` (MODIFY)

--- a/tests/cli/test_quota_cli_flags.py
+++ b/tests/cli/test_quota_cli_flags.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Tests for new CLI flags related to quota configuration (Task 2.2).
+"""
+
+import unittest
+
+from artist_bio_gen.cli.parser import create_argument_parser
+from artist_bio_gen.cli.main import _build_cli_overrides
+
+
+class TestQuotaCliFlags(unittest.TestCase):
+    def test_flags_present_and_override_mapping(self):
+        parser = create_argument_parser()
+        args = parser.parse_args([
+            "--input-file", "artists.csv",
+            "--quota-threshold", "0.9",
+            "--quota-monitoring", "false",
+            "--daily-limit", "3000",
+            "--pause-duration", "36",
+            "--quota-log-interval", "200",
+        ])
+
+        overrides = _build_cli_overrides(args)
+        self.assertEqual(overrides.get("QUOTA_THRESHOLD"), "0.9")
+        self.assertEqual(overrides.get("QUOTA_MONITORING"), "false")
+        self.assertEqual(overrides.get("DAILY_REQUEST_LIMIT"), "3000")
+        self.assertEqual(overrides.get("PAUSE_DURATION_HOURS"), "36")
+        self.assertEqual(overrides.get("QUOTA_LOG_INTERVAL"), "200")
+
+    def test_no_overrides_when_not_provided(self):
+        parser = create_argument_parser()
+        args = parser.parse_args(["--input-file", "artists.csv"])  # no new flags
+        overrides = _build_cli_overrides(args)
+        self.assertNotIn("QUOTA_THRESHOLD", overrides)
+        self.assertNotIn("QUOTA_MONITORING", overrides)
+        self.assertNotIn("DAILY_REQUEST_LIMIT", overrides)
+        self.assertNotIn("PAUSE_DURATION_HOURS", overrides)
+        self.assertNotIn("QUOTA_LOG_INTERVAL", overrides)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/config/test_quota_config.py
+++ b/tests/config/test_quota_config.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Tests for quota-related configuration (Task 2.2).
+
+Validates Env loads defaults, environment overrides, CLI overrides, and
+value validation for new quota parameters.
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from artist_bio_gen.config.env import Env, ConfigError
+
+
+class TestQuotaConfigDefaults(unittest.TestCase):
+    def setUp(self):
+        import artist_bio_gen.config.env as env_module
+        env_module._ENV = None
+
+    def tearDown(self):
+        import artist_bio_gen.config.env as env_module
+        env_module._ENV = None
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "key",
+        "DATABASE_URL": "postgresql://u:p@localhost:5432/db",
+    }, clear=True)
+    def test_defaults(self):
+        env = Env.load()
+        self.assertTrue(env.QUOTA_MONITORING)
+        self.assertEqual(env.QUOTA_THRESHOLD, 0.8)
+        self.assertIsNone(env.DAILY_REQUEST_LIMIT)
+        self.assertEqual(env.PAUSE_DURATION_HOURS, 24)
+        self.assertEqual(env.QUOTA_LOG_INTERVAL, 100)
+
+
+class TestQuotaConfigOverrides(unittest.TestCase):
+    def setUp(self):
+        import artist_bio_gen.config.env as env_module
+        env_module._ENV = None
+
+    def tearDown(self):
+        import artist_bio_gen.config.env as env_module
+        env_module._ENV = None
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "key",
+        "DATABASE_URL": "postgresql://u:p@localhost:5432/db",
+        "QUOTA_MONITORING": "false",
+        "QUOTA_THRESHOLD": "0.9",
+        "DAILY_REQUEST_LIMIT": "5000",
+        "PAUSE_DURATION_HOURS": "48",
+        "QUOTA_LOG_INTERVAL": "250",
+    }, clear=True)
+    def test_env_overrides(self):
+        env = Env.load()
+        self.assertFalse(env.QUOTA_MONITORING)
+        self.assertEqual(env.QUOTA_THRESHOLD, 0.9)
+        self.assertEqual(env.DAILY_REQUEST_LIMIT, 5000)
+        self.assertEqual(env.PAUSE_DURATION_HOURS, 48)
+        self.assertEqual(env.QUOTA_LOG_INTERVAL, 250)
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "key",
+        "DATABASE_URL": "postgresql://u:p@localhost:5432/db",
+    }, clear=True)
+    def test_cli_overrides(self):
+        cli = {
+            "QUOTA_MONITORING": "false",
+            "QUOTA_THRESHOLD": "0.85",
+            "DAILY_REQUEST_LIMIT": "2000",
+            "PAUSE_DURATION_HOURS": "12",
+            "QUOTA_LOG_INTERVAL": "50",
+        }
+        env = Env.load(cli)
+        self.assertFalse(env.QUOTA_MONITORING)
+        self.assertEqual(env.QUOTA_THRESHOLD, 0.85)
+        self.assertEqual(env.DAILY_REQUEST_LIMIT, 2000)
+        self.assertEqual(env.PAUSE_DURATION_HOURS, 12)
+        self.assertEqual(env.QUOTA_LOG_INTERVAL, 50)
+
+
+class TestQuotaConfigValidation(unittest.TestCase):
+    def setUp(self):
+        import artist_bio_gen.config.env as env_module
+        env_module._ENV = None
+
+    def tearDown(self):
+        import artist_bio_gen.config.env as env_module
+        env_module._ENV = None
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "key",
+        "DATABASE_URL": "postgresql://u:p@localhost:5432/db",
+        "QUOTA_THRESHOLD": "0.05",
+    }, clear=True)
+    def test_invalid_threshold_raises(self):
+        with self.assertRaises(ConfigError):
+            Env.load()
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "key",
+        "DATABASE_URL": "postgresql://u:p@localhost:5432/db",
+        "PAUSE_DURATION_HOURS": "0",
+    }, clear=True)
+    def test_invalid_pause_duration_low(self):
+        with self.assertRaises(ConfigError):
+            Env.load()
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "key",
+        "DATABASE_URL": "postgresql://u:p@localhost:5432/db",
+        "PAUSE_DURATION_HOURS": "100",
+    }, clear=True)
+    def test_invalid_pause_duration_high(self):
+        with self.assertRaises(ConfigError):
+            Env.load()
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "key",
+        "DATABASE_URL": "postgresql://u:p@localhost:5432/db",
+        "DAILY_REQUEST_LIMIT": "0",
+    }, clear=True)
+    def test_invalid_daily_limit(self):
+        with self.assertRaises(ConfigError):
+            Env.load()
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "key",
+        "DATABASE_URL": "postgresql://u:p@localhost:5432/db",
+        "QUOTA_LOG_INTERVAL": "0",
+    }, clear=True)
+    def test_invalid_log_interval(self):
+        with self.assertRaises(ConfigError):
+            Env.load()
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Implements Phase 2 - Task 2.2 from plans/rate_limit_implementation_plan.md.

Summary
- Add CLI flags: `--quota-threshold`, `--quota-monitoring`, `--daily-limit`, `--pause-duration`, `--quota-log-interval`
- Extend Env to load/validate: `QUOTA_MONITORING`, `QUOTA_THRESHOLD`, `DAILY_REQUEST_LIMIT`, `PAUSE_DURATION_HOURS`, `QUOTA_LOG_INTERVAL`
- Document new variables in `.env.example`
- Backward-compatible defaults; monitoring enabled by default

Files Changed
- `artist_bio_gen/cli/parser.py` (new flags + help)
- `artist_bio_gen/cli/main.py` (map CLI -> env overrides)
- `artist_bio_gen/config/env.py` (new fields + validation)
- `.env.example` (docs for new env vars)
- `tests/config/test_quota_config.py` (new tests)
- `tests/cli/test_quota_cli_flags.py` (new tests)
- `plans/rate_limit_implementation_plan.md` (mark Task 2.2 complete)

How To Run
```bash
# Targeted tests
python3 -m unittest tests/config/test_quota_config.py tests/cli/test_quota_cli_flags.py

# Full suite
python3 run_tests.py
```

Notes
- No new external deps; tests are offline-safe
- Maintains existing behavior unless flags/env are provided
