### PR TITLE
Issue #58: Simplify entrypoints and fix logging initialization

### DIFF
--- a/artist_bio_gen/__main__.py
+++ b/artist_bio_gen/__main__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""
+Enable execution of the artist_bio_gen package as a module.
+
+This allows running the package with: python -m artist_bio_gen
+"""
+
+from .cli.main import main
+
+if __name__ == "__main__":
+    main()

--- a/artist_bio_gen/main.py
+++ b/artist_bio_gen/main.py
@@ -3,20 +3,11 @@
 Artist Bio Generator Main Entry Point
 
 This module serves as the main entry point for the artist bio generator package.
-It coordinates all the separated modules and provides the primary CLI interface.
+It provides a minimal delegator to the CLI module without import-time side effects.
 """
-
-import logging
-
-# Import and setup utilities
-from .utils import setup_logging
 
 # Import CLI main function
 from .cli import main
-
-# Configure logging
-setup_logging()
-logger = logging.getLogger(__name__)
 
 
 # Main entry point - delegates to CLI module


### PR DESCRIPTION
## Summary
Removed import-time logging initialization from `artist_bio_gen/main.py` to prevent side effects and double initialization. The module now serves as a minimal delegator to the CLI.

## Changes
- 🔧 Removed `setup_logging()` call at import time in `artist_bio_gen/main.py`
- 📝 Updated main.py to be a minimal delegator without side effects
- ➕ Added `__main__.py` for package module execution (`python -m artist_bio_gen`)
- ✅ CLI remains the single logging initializer based on `--verbose` flag

## Testing
- ✅ All 369 tests passing
- ✅ No logging output at module import time
- ✅ `python3 -m artist_bio_gen.main` works correctly
- ✅ `python3 -m artist_bio_gen` works correctly
- ✅ Verbose flag properly controls DEBUG logging

## Benefits
- **No import-time side effects**: Module can be imported without triggering logging configuration
- **Single initialization point**: Logging is configured only once in CLI based on user flags
- **Predictable behavior**: No double initialization or conflicting configurations
- **Clean architecture**: Clear separation between module structure and runtime behavior

Closes #58

🤖 Generated with [Claude Code](https://claude.ai/code)